### PR TITLE
support groovy build files without crashing

### DIFF
--- a/modulecheck-core/src/main/kotlin/modulecheck/core/InheritedImplementationDependencyFinding.kt
+++ b/modulecheck-core/src/main/kotlin/modulecheck/core/InheritedImplementationDependencyFinding.kt
@@ -19,7 +19,6 @@ import modulecheck.api.Config
 import modulecheck.api.Finding.Position
 import modulecheck.api.Project2
 import modulecheck.psi.DslBlockVisitor
-import modulecheck.psi.internal.asKtFile
 
 data class InheritedImplementationDependencyFinding(
   override val dependentProject: Project2,
@@ -40,7 +39,9 @@ data class InheritedImplementationDependencyFinding(
 
     val fromPath = from?.path ?: return false
 
-    val result = visitor.parse(dependentProject.buildFile.asKtFile()) ?: return false
+    val kotlinBuildFile = kotlinBuildFileOrNull() ?: return false
+
+    val result = visitor.parse(kotlinBuildFile) ?: return false
 
     val match = result.elements.firstOrNull {
       it.psiElement.text.contains(fromPath)

--- a/modulecheck-core/src/main/kotlin/modulecheck/core/MCP.kt
+++ b/modulecheck-core/src/main/kotlin/modulecheck/core/MCP.kt
@@ -18,7 +18,6 @@ package modulecheck.core
 import modulecheck.api.*
 import modulecheck.api.Config.*
 import modulecheck.api.Finding.Position
-import modulecheck.api.JvmFile
 import modulecheck.api.psi.PsiElementWithSurroundingText
 import modulecheck.core.files.KotlinFile
 import modulecheck.core.files.XmlFile
@@ -219,6 +218,7 @@ class MCP private constructor(
         }
       }
   }
+
   fun dependents() = cache
     .values
     .filter {
@@ -293,8 +293,10 @@ class MCP private constructor(
     parent: Project2,
     configuration: Config
   ): PsiElementWithSurroundingText? {
+    val kotlinBuildFile = parent.buildFile.asKtsFileOrNull() ?: return null
+
     val result = DslBlockVisitor("dependencies")
-      .parse(parent.buildFile.asKtFile())
+      .parse(kotlinBuildFile)
       ?: return null
 
     val p = ProjectDependencyDeclarationVisitor(configuration, project.path)

--- a/modulecheck-core/src/main/kotlin/modulecheck/core/finding.kt
+++ b/modulecheck-core/src/main/kotlin/modulecheck/core/finding.kt
@@ -1,0 +1,7 @@
+package modulecheck.core
+
+import modulecheck.api.Finding
+import modulecheck.psi.internal.asKtsFileOrNull
+import org.jetbrains.kotlin.psi.KtFile
+
+fun Finding.kotlinBuildFileOrNull(): KtFile? = dependentProject.buildFile.asKtsFileOrNull()

--- a/modulecheck-core/src/main/kotlin/modulecheck/core/internal/file.kt
+++ b/modulecheck-core/src/main/kotlin/modulecheck/core/internal/file.kt
@@ -18,13 +18,14 @@ package modulecheck.core.internal
 import modulecheck.core.files.JavaFile
 import modulecheck.core.files.KotlinFile
 import modulecheck.psi.internal.asKtFile
+import modulecheck.psi.internal.asKtFileOrNull
 import org.jetbrains.kotlin.incremental.isJavaFile
 import org.jetbrains.kotlin.incremental.isKotlinFile
 import org.jetbrains.kotlin.resolve.BindingContext
 import java.io.File
 
 fun Sequence<File>.ktFiles() = filter { it.isFile }
-  .mapNotNull { it.asKtFile() }
+  .mapNotNull { it.asKtFileOrNull() }
 
 fun File.jvmFiles(bindingContext: BindingContext) = walkTopDown()
   .files()

--- a/modulecheck-core/src/main/kotlin/modulecheck/core/overshot/OverShotDependencyFinding.kt
+++ b/modulecheck-core/src/main/kotlin/modulecheck/core/overshot/OverShotDependencyFinding.kt
@@ -20,8 +20,8 @@ import modulecheck.api.Finding.Position
 import modulecheck.api.Project2
 import modulecheck.core.DependencyFinding
 import modulecheck.core.MCP
+import modulecheck.core.kotlinBuildFileOrNull
 import modulecheck.psi.DslBlockVisitor
-import modulecheck.psi.internal.asKtFile
 
 data class OverShotDependencyFinding(
   override val dependentProject: Project2,
@@ -38,11 +38,13 @@ data class OverShotDependencyFinding(
   }
 
   override fun fix(): Boolean {
-    val parser = DslBlockVisitor("dependencies")
+    val visitor = DslBlockVisitor("dependencies")
 
     val fromPath = from?.path ?: return false
 
-    val result = parser.parse(dependentProject.buildFile.asKtFile()) ?: return false
+    val kotlinBuildFile = kotlinBuildFileOrNull() ?: return false
+
+    val result = visitor.parse(kotlinBuildFile) ?: return false
 
     val match = result.elements.firstOrNull {
       it.psiElement.text.contains(fromPath)

--- a/modulecheck-core/src/main/kotlin/modulecheck/core/rule/AbstractRule.kt
+++ b/modulecheck-core/src/main/kotlin/modulecheck/core/rule/AbstractRule.kt
@@ -17,6 +17,8 @@ package modulecheck.core.rule
 
 import modulecheck.api.Project2
 import modulecheck.core.MCP
+import modulecheck.psi.internal.asKtsFileOrNull
+import org.jetbrains.kotlin.psi.KtFile
 
 abstract class AbstractRule<T>(
   protected val project: Project2,
@@ -25,6 +27,8 @@ abstract class AbstractRule<T>(
 ) {
 
   abstract fun check(): List<T>
+
+  protected fun kotlinBuildFileOrNull(): KtFile? = project.buildFile.asKtsFileOrNull()
 
   protected fun Project2.moduleCheckProjects() =
     project.rootProject.allprojects

--- a/modulecheck-core/src/main/kotlin/modulecheck/core/rule/sort/SortDependenciesRule.kt
+++ b/modulecheck-core/src/main/kotlin/modulecheck/core/rule/sort/SortDependenciesRule.kt
@@ -20,10 +20,9 @@ import modulecheck.api.Finding.Position
 import modulecheck.api.Fixable
 import modulecheck.api.Project2
 import modulecheck.api.psi.PsiElementWithSurroundingText
+import modulecheck.core.kotlinBuildFileOrNull
 import modulecheck.core.rule.AbstractRule
-import modulecheck.psi.*
 import modulecheck.psi.DslBlockVisitor
-import modulecheck.psi.internal.*
 import java.util.*
 
 fun List<PsiElementWithSurroundingText>.grouped() = groupBy {
@@ -48,7 +47,9 @@ class SortDependenciesFinding(
   override fun positionOrNull(): Position? = null
 
   override fun fix(): Boolean {
-    val result = visitor.parse(dependentProject.buildFile.asKtFile()) ?: return false
+    val kotlinBuildFile = kotlinBuildFileOrNull() ?: return false
+
+    val result = visitor.parse(kotlinBuildFile) ?: return false
 
     val sorted = result
       .elements
@@ -80,7 +81,9 @@ class SortDependenciesRule(
   project, alwaysIgnore, ignoreAll
 ) {
   override fun check(): List<SortDependenciesFinding> {
-    val result = visitor.parse(project.buildFile.asKtFile()) ?: return emptyList()
+    val kotlinBuildFile = kotlinBuildFileOrNull() ?: return emptyList()
+
+    val result = visitor.parse(kotlinBuildFile) ?: return emptyList()
 
     val sorted = result
       .elements

--- a/modulecheck-core/src/main/kotlin/modulecheck/core/rule/sort/SortPluginsRule.kt
+++ b/modulecheck-core/src/main/kotlin/modulecheck/core/rule/sort/SortPluginsRule.kt
@@ -20,10 +20,9 @@ import modulecheck.api.Finding.Position
 import modulecheck.api.Fixable
 import modulecheck.api.Project2
 import modulecheck.api.psi.PsiElementWithSurroundingText
+import modulecheck.core.kotlinBuildFileOrNull
 import modulecheck.core.rule.AbstractRule
-import modulecheck.psi.*
 import modulecheck.psi.DslBlockVisitor
-import modulecheck.psi.internal.*
 import java.util.*
 
 class SortPluginsFinding(
@@ -38,7 +37,9 @@ class SortPluginsFinding(
   override fun positionOrNull(): Position? = null
 
   override fun fix(): Boolean {
-    val result = visitor.parse(dependentProject.buildFile.asKtFile()) ?: return false
+    val kotlinBuildFile = kotlinBuildFileOrNull() ?: return false
+
+    val result = visitor.parse(kotlinBuildFile) ?: return false
 
     val sorted = result
       .elements
@@ -66,7 +67,9 @@ class SortPluginsRule(
   project, alwaysIgnore, ignoreAll
 ) {
   override fun check(): List<SortPluginsFinding> {
-    val result = visitor.parse(project.buildFile.asKtFile()) ?: return emptyList()
+    val kotlinBuildFile = kotlinBuildFileOrNull() ?: return emptyList()
+
+    val result = visitor.parse(kotlinBuildFile) ?: return emptyList()
 
     val sorted = result
       .elements


### PR DESCRIPTION
The project has been blindly treating every build file as a Kotlin file, then turning them into `KtFile`.  This sometimes actually works fine with Groovy files, but often causes a crash.

This change just exits out of a function before parsing the build file if it wouldn't be reading a `.kts` file.