### PR TITLE
Lint main + allWarningsAsErrors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs :
           java-version : 14
 
       - name : all tests
-        run : ./gradlew testJvm -Pmodulecheck.kotlinVersion=${{ matrix.kotlin-version }} -Pmodulecheck.gradleVersion=${{ matrix.gradle-version }} -Pmodulecheck.agpVersion=${{ matrix.agp-version }}
+        run : ./gradlew lintMain testJvm -Pmodulecheck.kotlinVersion=${{ matrix.kotlin-version }} -Pmodulecheck.gradleVersion=${{ matrix.gradle-version }} -Pmodulecheck.agpVersion=${{ matrix.agp-version }} --rerun-tasks
 
       - name : Archive test results
         uses : actions/upload-artifact@v2
@@ -123,7 +123,7 @@ jobs :
           java-version : 14
 
       - name : all tests
-        run : ./gradlew testJvm
+        run : ./gradlew lintMain testJvm --rerun-tasks
 
       - name : Archive test results
         uses : actions/upload-artifact@v2

--- a/buildSrc/src/main/kotlin/Common.kt
+++ b/buildSrc/src/main/kotlin/Common.kt
@@ -21,12 +21,14 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 fun Project.common() {
 
+  val ci = !System.getenv("CI").isNullOrBlank()
+
   tasks.withType<KotlinCompile>()
     .configureEach {
 
       kotlinOptions {
 
-//        allWarningsAsErrors = true
+        allWarningsAsErrors = ci
 
         jvmTarget = "1.8"
       }

--- a/buildSrc/src/main/kotlin/androidLibrary.gradle.kts
+++ b/buildSrc/src/main/kotlin/androidLibrary.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Rick Busarow
+ * Copyright (C) 2021 Rick Busarow
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,11 +13,28 @@
  * limitations under the License.
  */
 
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 apply(plugin = "com.android.library")
 apply(plugin = "org.jetbrains.kotlin.android")
 
 commonAndroid()
 common()
+
+val lintMain by tasks.registering {
+
+  doFirst {
+    tasks.withType<KotlinCompile>()
+      .configureEach {
+        kotlinOptions {
+          allWarningsAsErrors = true
+        }
+      }
+  }
+}
+lintMain {
+  finalizedBy("compileKotlin", "lintDebug")
+}
 
 val testJvm by tasks.registering {
   dependsOn("testDebugUnitTest")

--- a/buildSrc/src/main/kotlin/javaLibrary.gradle.kts
+++ b/buildSrc/src/main/kotlin/javaLibrary.gradle.kts
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   kotlin("jvm")
 }
@@ -38,6 +40,21 @@ java {
   // This is different than the Kotlin jvm target.
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+val lintMain by tasks.registering {
+
+  doFirst {
+    tasks.withType<KotlinCompile>()
+      .configureEach {
+        kotlinOptions {
+          allWarningsAsErrors = true
+        }
+      }
+  }
+}
+lintMain {
+  finalizedBy("compileKotlin")
 }
 
 val testJvm by tasks.registering {

--- a/modulecheck-core/src/main/kotlin/modulecheck/core/MCP.kt
+++ b/modulecheck-core/src/main/kotlin/modulecheck/core/MCP.kt
@@ -188,17 +188,17 @@ class MCP private constructor(
     } else emptySet()
   }
 
-/*  val testAndroidResDeclarations by lazy {
+  /*  val testAndroidResDeclarations by lazy {
 
-    val rPackage = androidPackageOrNull
-    val resDir = project.testResRootOrNull()
+      val rPackage = androidPackageOrNull
+      val resDir = project.testResRootOrNull()
 
-    if (isAndroid && rPackage != null && resDir != null) {
-      AndroidResourceParser.parse(resDir)
-    } else emptySet()
-  }
+      if (isAndroid && rPackage != null && resDir != null) {
+        AndroidResourceParser.parse(resDir)
+      } else emptySet()
+    }
 
-  val testDeclarations by lazy { testFiles.flatMap { it.declarations }.toSet() }*/
+    val testDeclarations by lazy { testFiles.flatMap { it.declarations }.toSet() }*/
   val mustBeApi by lazy {
 
     val noIdeaWhereTheyComeFrom = mainFiles
@@ -266,13 +266,22 @@ class MCP private constructor(
   fun getMainDepth(): Int {
     val all = dependencies.main()
 
-    return if (all.isEmpty()) 0
-    else all.map { it.mcp().getMainDepth() }.max()!! + 1
+    return if (all.isEmpty()) {
+      0
+    } else {
+      // `max` is deprecated but older Gradle versions use Kotlin 1.3.72 where the `maxOrNull` replacement doesn't exist
+      @Suppress("DEPRECATION")
+      all
+        .map { it.mcp().getMainDepth() }
+        .max()!! + 1
+    }
   }
 
   fun getTestDepth(): Int = if (dependencies.testImplementation.isEmpty()) {
     0
   } else {
+    // `max` is deprecated but older Gradle versions use Kotlin 1.3.72 where the `maxOrNull` replacement doesn't exist
+    @Suppress("DEPRECATION")
     dependencies.testImplementation
       .map { it.mcp().getMainDepth() }
       .max()!! + 1
@@ -282,6 +291,8 @@ class MCP private constructor(
     get() = if (dependencies.androidTest.isEmpty()) {
       0
     } else {
+      // `max` is deprecated but older Gradle versions use Kotlin 1.3.72 where the `maxOrNull` replacement doesn't exist
+      @Suppress("DEPRECATION")
       dependencies.androidTest
         .map { it.mcp().getMainDepth() }
         .max()!! + 1

--- a/modulecheck-plugin/src/main/kotlin/modulecheck/gradle/task/ModuleCheckTask.kt
+++ b/modulecheck-plugin/src/main/kotlin/modulecheck/gradle/task/ModuleCheckTask.kt
@@ -25,9 +25,7 @@ import modulecheck.core.rule.android.DisableAndroidResourcesRule
 import modulecheck.core.rule.android.DisableViewBindingRule
 import modulecheck.core.rule.sort.SortDependenciesRule
 import modulecheck.core.rule.sort.SortPluginsRule
-import modulecheck.gradle.ModuleCheckExtension
 import modulecheck.gradle.project2
-import org.gradle.kotlin.dsl.getByType
 
 abstract class ModuleCheckTask : AbstractModuleCheckTask() {
 
@@ -86,27 +84,15 @@ abstract class ModuleCheckTask : AbstractModuleCheckTask() {
             }
 
             if (checks.sortDependencies) {
-              addAll(
-                SortDependenciesRule(settings)
-                  .check(proj)
-              )
+              addAll(SortDependenciesRule(settings).check(proj))
             }
 
             if (checks.sortPlugins) {
-              addAll(
-                SortPluginsRule(settings)
-                  .check(proj)
-              )
+              addAll(SortPluginsRule(settings).check(proj))
             }
 
             if (checks.kapt) {
-              val additionalKaptMatchers = project.extensions
-                .getByType<ModuleCheckExtension>()
-                .additionalKaptMatchers
-
-              addAll(
-                UnusedKaptRule(settings).check(proj)
-              )
+              addAll(UnusedKaptRule(settings).check(proj))
             }
 
             if (checks.anvilFactories) {


### PR DESCRIPTION
Sets `KotlinOptions.allWarningsAsErrors` to true while in CI, or when running a new `lintMain` task.