### PR TITLE
reverse the output of the PSI everythingPrinter

### DIFF
--- a/modulecheck-parsing/psi/src/main/kotlin/modulecheck/parsing/psi/PsiEverythingPrinter.kt
+++ b/modulecheck-parsing/psi/src/main/kotlin/modulecheck/parsing/psi/PsiEverythingPrinter.kt
@@ -20,14 +20,16 @@ import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
 
 fun everythingPrinter() = object : KtTreeVisitorVoid() {
   override fun visitElement(element: PsiElement) {
-    super.visitElement(element)
+
+    val thisName = element::class.java.simpleName
+    val parentName = element.parent?.let { it::class.java.simpleName }
+
     println(
-      """ ***************************************************************************
-      |
-      |${element.text}           -- ${element::class.java}
-      |
+      """ ******************************** -- $thisName  ${parentName?.let { "-- parent: $parentName" } ?: ""}
+      |${element.text}
       |_________________________________________________________________________________
     """.trimMargin()
     )
+    super.visitElement(element)
   }
 }


### PR DESCRIPTION
This prints the parents first and leaf nodes last, instead of the other way around.