### PR TITLE
remove typesafe project accessors and tree shake

### DIFF
--- a/dependabot-bridge/build.gradle.kts
+++ b/dependabot-bridge/build.gradle.kts
@@ -28,14 +28,17 @@ dependencies {
   dependencySync("com.rickbusarow.hermit:hermit-mockk:0.9.5")
   dependencySync("com.squareup.anvil:gradle-plugin:2.3.7")
   dependencySync("com.squareup:kotlinpoet:1.10.2")
+
   dependencySync("io.kotest:kotest-assertions-core-jvm:4.6.3")
   dependencySync("io.kotest:kotest-property-jvm:4.6.3")
   dependencySync("io.kotest:kotest-runner-junit5-jvm:4.6.3")
+
   dependencySync("javax.inject:javax.inject:1")
-  dependencySync("org.antlr:antlr4:4.9.2")
-  dependencySync("org.antlr:antlr4-runtime:4.9.2")
-  dependencySync("org.unbescape:unbescape:1.1.6.RELEASE")
+
   dependencySync("net.swiftzer.semver:semver:1.1.1")
+
+  dependencySync("org.antlr:antlr4-runtime:4.9.2")
+  dependencySync("org.antlr:antlr4:4.9.2")
   dependencySync("org.codehaus.groovy:groovy-xml:3.0.9")
   dependencySync("org.codehaus.groovy:groovy:3.0.9")
   dependencySync("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.5.31")
@@ -47,4 +50,5 @@ dependencies {
   dependencySync("org.junit.jupiter:junit-jupiter-api:5.8.1")
   dependencySync("org.junit.jupiter:junit-jupiter-engine:5.8.1")
   dependencySync("org.junit.jupiter:junit-jupiter-params:5.8.1")
+  dependencySync("org.unbescape:unbescape:1.1.6.RELEASE")
 }

--- a/modulecheck-api/build.gradle.kts
+++ b/modulecheck-api/build.gradle.kts
@@ -23,10 +23,10 @@ dependencies {
   api(libs.kotlin.compiler)
   api(libs.semVer)
 
-  api(projects.modulecheckParsing.java)
-  api(projects.modulecheckParsing.api)
-  api(projects.modulecheckParsing.psi)
-  api(projects.modulecheckParsing.xml)
+  api(project(path = ":modulecheck-parsing:api"))
+  api(project(path = ":modulecheck-parsing:java"))
+  api(project(path = ":modulecheck-parsing:psi"))
+  api(project(path = ":modulecheck-parsing:xml"))
 
   implementation(libs.agp)
   implementation(libs.groovy)
@@ -36,7 +36,4 @@ dependencies {
   testImplementation(libs.bundles.hermit)
   testImplementation(libs.bundles.jUnit)
   testImplementation(libs.bundles.kotest)
-
-  testImplementation(projects.modulecheckInternalTesting)
-  testImplementation(projects.modulecheckSpecs)
 }

--- a/modulecheck-core/build.gradle.kts
+++ b/modulecheck-core/build.gradle.kts
@@ -22,13 +22,14 @@ dependencies {
 
   api(libs.kotlin.compiler)
 
-  api(projects.modulecheckApi)
-  api(projects.modulecheckParsing.api)
-  api(projects.modulecheckParsing.groovyAntlr)
-  api(projects.modulecheckParsing.psi)
-  api(projects.modulecheckParsing.xml)
-  api(projects.modulecheckReporting.checkstyle)
-  api(projects.modulecheckReporting.console)
+  api(project(path = ":modulecheck-api"))
+  api(project(path = ":modulecheck-parsing:api"))
+  api(project(path = ":modulecheck-parsing:groovy-antlr"))
+  api(project(path = ":modulecheck-parsing:java"))
+  api(project(path = ":modulecheck-parsing:psi"))
+  api(project(path = ":modulecheck-parsing:xml"))
+  api(project(path = ":modulecheck-reporting:checkstyle"))
+  api(project(path = ":modulecheck-reporting:console"))
 
   implementation(libs.agp)
   implementation(libs.groovy)
@@ -40,6 +41,5 @@ dependencies {
   testImplementation(libs.bundles.kotest)
   testImplementation(libs.kotlin.reflect)
 
-  testImplementation(projects.modulecheckInternalTesting)
-  testImplementation(projects.modulecheckSpecs)
+  testImplementation(project(path = ":modulecheck-internal-testing"))
 }

--- a/modulecheck-parsing/api/build.gradle.kts
+++ b/modulecheck-parsing/api/build.gradle.kts
@@ -21,19 +21,16 @@ plugins {
 
 dependencies {
 
-  compileOnly(gradleApi())
-
   api(libs.semVer)
 
+  compileOnly(gradleApi())
+
   implementation(libs.agp)
+  implementation(libs.groovy)
   implementation(libs.javaParser)
   implementation(libs.kotlin.reflect)
-  implementation(libs.groovy)
 
   testImplementation(libs.bundles.hermit)
   testImplementation(libs.bundles.jUnit)
   testImplementation(libs.bundles.kotest)
-
-  testImplementation(projects.modulecheckInternalTesting)
-  testImplementation(projects.modulecheckSpecs)
 }

--- a/modulecheck-parsing/groovy-antlr/build.gradle.kts
+++ b/modulecheck-parsing/groovy-antlr/build.gradle.kts
@@ -21,24 +21,19 @@ plugins {
 
 dependencies {
 
+  api(project(path = ":modulecheck-parsing:api"))
+
   compileOnly(gradleApi())
 
-  implementation(libs.kotlin.compiler)
-
-  api(projects.modulecheckParsing.api)
-
+  implementation(libs.agp)
   implementation(libs.antlr.core)
   implementation(libs.antlr.runtime)
-
-  implementation(libs.agp)
-  implementation(libs.javaParser)
-  implementation(libs.kotlin.reflect)
   implementation(libs.groovy)
+  implementation(libs.javaParser)
+  implementation(libs.kotlin.compiler)
+  implementation(libs.kotlin.reflect)
 
   testImplementation(libs.bundles.hermit)
   testImplementation(libs.bundles.jUnit)
   testImplementation(libs.bundles.kotest)
-
-  testImplementation(projects.modulecheckInternalTesting)
-  testImplementation(projects.modulecheckSpecs)
 }

--- a/modulecheck-parsing/java/build.gradle.kts
+++ b/modulecheck-parsing/java/build.gradle.kts
@@ -23,21 +23,20 @@ dependencies {
 
   api(libs.kotlin.compiler)
 
-  api(projects.modulecheckParsing.api)
-
-  compileOnly("org.codehaus.groovy:groovy-xml:3.0.9")
+  api(project(path = ":modulecheck-parsing:api"))
 
   compileOnly(gradleApi())
 
+  compileOnly("org.codehaus.groovy:groovy-xml:3.0.9")
+
   implementation(libs.agp)
+  implementation(libs.groovy)
   implementation(libs.javaParser)
   implementation(libs.kotlin.reflect)
-  implementation(libs.groovy)
 
   testImplementation(libs.bundles.hermit)
   testImplementation(libs.bundles.jUnit)
   testImplementation(libs.bundles.kotest)
 
-  testImplementation(projects.modulecheckInternalTesting)
-  testImplementation(projects.modulecheckSpecs)
+  testImplementation(project(path = ":modulecheck-internal-testing"))
 }

--- a/modulecheck-parsing/psi/build.gradle.kts
+++ b/modulecheck-parsing/psi/build.gradle.kts
@@ -23,21 +23,18 @@ dependencies {
 
   api(libs.kotlin.compiler)
 
-  api(projects.modulecheckParsing.api)
-
-  compileOnly("org.codehaus.groovy:groovy-xml:3.0.9")
+  api(project(path = ":modulecheck-parsing:api"))
 
   compileOnly(gradleApi())
 
   implementation(libs.agp)
+  implementation(libs.groovy)
   implementation(libs.javaParser)
   implementation(libs.kotlin.reflect)
-  implementation(libs.groovy)
 
   testImplementation(libs.bundles.hermit)
   testImplementation(libs.bundles.jUnit)
   testImplementation(libs.bundles.kotest)
 
-  testImplementation(projects.modulecheckInternalTesting)
-  testImplementation(projects.modulecheckSpecs)
+  testImplementation(project(path = ":modulecheck-internal-testing"))
 }

--- a/modulecheck-parsing/xml/build.gradle.kts
+++ b/modulecheck-parsing/xml/build.gradle.kts
@@ -23,21 +23,18 @@ dependencies {
 
   api(libs.kotlin.compiler)
 
-  api(projects.modulecheckParsing.api)
-
-  compileOnly(libs.groovyXml)
+  api(project(path = ":modulecheck-parsing:api"))
 
   compileOnly(gradleApi())
 
+  compileOnly(libs.groovyXml)
+
   implementation(libs.agp)
+  implementation(libs.groovy)
   implementation(libs.javaParser)
   implementation(libs.kotlin.reflect)
-  implementation(libs.groovy)
 
   testImplementation(libs.bundles.hermit)
   testImplementation(libs.bundles.jUnit)
   testImplementation(libs.bundles.kotest)
-
-  testImplementation(projects.modulecheckInternalTesting)
-  testImplementation(projects.modulecheckSpecs)
 }

--- a/modulecheck-plugin/build.gradle.kts
+++ b/modulecheck-plugin/build.gradle.kts
@@ -26,8 +26,11 @@ dependencies {
   api(libs.javax.inject)
   api(libs.kotlin.compiler)
 
-  api(projects.modulecheckApi)
-  api(projects.modulecheckCore)
+  api(project(path = ":modulecheck-api"))
+  api(project(path = ":modulecheck-core"))
+  api(project(path = ":modulecheck-parsing:api"))
+  api(project(path = ":modulecheck-parsing:xml"))
+  api(project(path = ":modulecheck-reporting:console"))
 
   implementation(libs.agp)
   implementation(libs.anvil)
@@ -37,19 +40,13 @@ dependencies {
   implementation(libs.kotlin.reflect)
   implementation(libs.semVer)
 
-  implementation(projects.modulecheckParsing.api)
-  implementation(projects.modulecheckParsing.groovyAntlr)
-  implementation(projects.modulecheckParsing.psi)
-  implementation(projects.modulecheckReporting.console)
-  implementation(projects.modulecheckReporting.checkstyle)
-
   testImplementation(libs.bundles.hermit)
   testImplementation(libs.bundles.jUnit)
   testImplementation(libs.bundles.kotest)
   testImplementation(libs.kotlinPoet)
 
-  testImplementation(projects.modulecheckInternalTesting)
-  testImplementation(projects.modulecheckSpecs)
+  testImplementation(project(path = ":modulecheck-internal-testing"))
+  testImplementation(project(path = ":modulecheck-specs"))
 }
 
 gradlePlugin {

--- a/modulecheck-reporting/checkstyle/build.gradle.kts
+++ b/modulecheck-reporting/checkstyle/build.gradle.kts
@@ -20,13 +20,11 @@ plugins {
 
 dependencies {
 
-  api(projects.modulecheckApi)
+  api(project(path = ":modulecheck-api"))
 
   implementation(libs.unbescape)
 
   testImplementation(libs.bundles.hermit)
   testImplementation(libs.bundles.jUnit)
   testImplementation(libs.bundles.kotest)
-
-  testImplementation(projects.modulecheckInternalTesting)
 }

--- a/modulecheck-reporting/checkstyle/gradle.properties
+++ b/modulecheck-reporting/checkstyle/gradle.properties
@@ -13,6 +13,6 @@
 # limitations under the License.
 #
 
-POM_NAME=modulecheck-reporting-xml
-POM_ARTIFACT_ID=modulecheck-reporting-xml
+POM_NAME=modulecheck-reporting-checkstyle
+POM_ARTIFACT_ID=modulecheck-reporting-checkstyle
 POM_PACKAGING=jar

--- a/modulecheck-reporting/console/build.gradle.kts
+++ b/modulecheck-reporting/console/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
 dependencies {
 
-  api(projects.modulecheckApi)
+  api(project(path = ":modulecheck-api"))
 
   testImplementation(libs.bundles.hermit)
   testImplementation(libs.bundles.jUnit)

--- a/modulecheck-specs/build.gradle.kts
+++ b/modulecheck-specs/build.gradle.kts
@@ -34,6 +34,4 @@ dependencies {
 
   testImplementation(libs.bundles.jUnit)
   testImplementation(libs.bundles.kotest)
-
-  testImplementation(projects.modulecheckInternalTesting)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -54,7 +54,6 @@ gradleEnterprise {
 
 rootProject.name = "ModuleCheck"
 enableFeaturePreview("VERSION_CATALOGS")
-enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 include(
   ":dependabot-bridge",


### PR DESCRIPTION
the typesafe version's always red in .kts files, even after a successful sync