### PR TITLE
introduce ProjectTest

### DIFF
--- a/modulecheck-api/build.gradle.kts
+++ b/modulecheck-api/build.gradle.kts
@@ -16,7 +16,10 @@
 plugins {
   javaLibrary
   id("com.vanniktech.maven.publish")
+  id("java-test-fixtures")
 }
+
+val isIdeSync = System.getProperty("idea.sync.active", "false").toBoolean()
 
 dependencies {
 
@@ -32,6 +35,16 @@ dependencies {
   implementation(libs.groovy)
   implementation(libs.groovyXml)
   implementation(libs.kotlin.reflect)
+
+  testFixturesApi(project(path = ":modulecheck-internal-testing"))
+  testFixturesApi(libs.bundles.hermit)
+
+  if (isIdeSync) {
+    compileOnly(project(path = ":modulecheck-internal-testing"))
+    compileOnly(libs.bundles.hermit)
+    compileOnly(libs.bundles.jUnit)
+    compileOnly(libs.bundles.kotest)
+  }
 
   testImplementation(libs.bundles.hermit)
   testImplementation(libs.bundles.jUnit)

--- a/modulecheck-api/src/testFixtures/kotlin/modulecheck/api/test/McProjectBuilderScope.kt
+++ b/modulecheck-api/src/testFixtures/kotlin/modulecheck/api/test/McProjectBuilderScope.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2021 Rick Busarow
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package modulecheck.api.test
+
+import modulecheck.parsing.*
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+
+class McProjectBuilderScope(
+  var path: String,
+  var projectDir: File,
+  var buildFile: File,
+  val configurations: MutableMap<ConfigurationName, Config> = mutableMapOf(),
+  val projectDependencies: ProjectDependencies = ProjectDependencies(mutableMapOf()),
+  var hasKapt: Boolean = false,
+  val sourceSets: MutableMap<SourceSetName, SourceSet> = mutableMapOf(
+    SourceSetName.MAIN to SourceSet(SourceSetName.MAIN)
+  ),
+  var anvilGradlePlugin: AnvilGradlePlugin? = null,
+  val projectCache: ConcurrentHashMap<String, McProject> = ConcurrentHashMap()
+)

--- a/modulecheck-api/src/testFixtures/kotlin/modulecheck/api/test/McProjectBuilderScope.kt
+++ b/modulecheck-api/src/testFixtures/kotlin/modulecheck/api/test/McProjectBuilderScope.kt
@@ -19,7 +19,8 @@ import modulecheck.parsing.*
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 
-class McProjectBuilderScope(
+@Suppress("LongParameterList")
+data class McProjectBuilderScope(
   var path: String,
   var projectDir: File,
   var buildFile: File,

--- a/modulecheck-api/src/testFixtures/kotlin/modulecheck/api/test/ProjectTest.kt
+++ b/modulecheck-api/src/testFixtures/kotlin/modulecheck/api/test/ProjectTest.kt
@@ -33,7 +33,8 @@ abstract class ProjectTest : BaseTest() {
   }
 
   fun McProjectBuilderScope.childProject(
-    path: String, config: McProjectBuilderScope.() -> Unit
+    path: String,
+    config: McProjectBuilderScope.() -> Unit
   ): McProject {
 
     val appendedPath = (this@childProject.path + path).replace(":{2,}".toRegex(), ":")

--- a/modulecheck-api/src/testFixtures/kotlin/modulecheck/api/test/ProjectTest.kt
+++ b/modulecheck-api/src/testFixtures/kotlin/modulecheck/api/test/ProjectTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2021 Rick Busarow
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package modulecheck.api.test
+
+import modulecheck.api.RealMcProject
+import modulecheck.parsing.ConfigurationName
+import modulecheck.parsing.ConfiguredProjectDependency
+import modulecheck.parsing.McProject
+import modulecheck.testing.BaseTest
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+
+abstract class ProjectTest : BaseTest() {
+
+  val projectCache: ConcurrentHashMap<String, McProject> by resets { ConcurrentHashMap() }
+
+  fun project(path: String, config: McProjectBuilderScope.() -> Unit): McProject {
+
+    return createProject(path, config)
+  }
+
+  fun McProjectBuilderScope.childProject(
+    path: String, config: McProjectBuilderScope.() -> Unit
+  ): McProject {
+
+    val appendedPath = (this@childProject.path + path).replace(":{2,}".toRegex(), ":")
+
+    return createProject(appendedPath, config)
+  }
+
+  private fun createProject(path: String, config: McProjectBuilderScope.() -> Unit): McProject {
+
+    val projectRoot = File(testProjectDir, path.replace(":", File.separator))
+      .also { it.mkdirs() }
+
+    val buildFile = File(projectRoot, "build.gradle.kts")
+      .also { it.createNewFile() }
+
+    val builder = McProjectBuilderScope(path, projectRoot, buildFile, projectCache = projectCache)
+      .also { it.config() }
+
+    val delegate = RealMcProject(
+      path = builder.path,
+      projectDir = builder.projectDir,
+      buildFile = builder.buildFile,
+      configurations = builder.configurations,
+      hasKapt = builder.hasKapt,
+      sourceSets = builder.sourceSets,
+      projectCache = builder.projectCache,
+      anvilGradlePlugin = builder.anvilGradlePlugin,
+      projectDependencies = lazy { builder.projectDependencies }
+    )
+
+    return delegate
+      .also { projectCache[it.path] = it }
+  }
+
+  fun McProject.addDependency(
+    configurationName: ConfigurationName,
+    project: McProject,
+    asTestFixture: Boolean = false
+  ) {
+
+    val old = projectDependencies[configurationName].orEmpty()
+
+    val cpd = ConfiguredProjectDependency(configurationName, project, asTestFixture)
+
+    projectDependencies[configurationName] = old + cpd
+  }
+
+  fun McProjectBuilderScope.addDependency(
+    configurationName: ConfigurationName,
+    project: McProject,
+    asTestFixture: Boolean = false
+  ) {
+
+    val old = projectDependencies[configurationName].orEmpty()
+
+    val cpd = ConfiguredProjectDependency(configurationName, project, asTestFixture)
+
+    projectDependencies[configurationName] = old + cpd
+  }
+
+  fun allProjects(): List<McProject> = projectCache.values.toList()
+}

--- a/modulecheck-api/src/testFixtures/kotlin/modulecheck/api/test/TestSettings.kt
+++ b/modulecheck-api/src/testFixtures/kotlin/modulecheck/api/test/TestSettings.kt
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-package modulecheck.core
+package modulecheck.api.test
 
 import modulecheck.api.KaptMatcher
 import modulecheck.api.settings.*

--- a/modulecheck-api/src/testFixtures/kotlin/modulecheck/api/test/TestSettings.kt
+++ b/modulecheck-api/src/testFixtures/kotlin/modulecheck/api/test/TestSettings.kt
@@ -35,7 +35,8 @@ data class TestSettings(
   fun sort(block: SortSettings.() -> Unit) = Unit
 }
 
-class TestChecksSettings(
+@Suppress("LongParameterList")
+data class TestChecksSettings(
   override var redundantDependency: Boolean = ChecksSettings.REDUNDANT_DEPENDENCY_DEFAULT,
   override var unusedDependency: Boolean = ChecksSettings.UNUSED_DEPENDENCY_DEFAULT,
   override var overShotDependency: Boolean = ChecksSettings.OVERSHOT_DEPENDENCY_DEFAULT,

--- a/modulecheck-core/build.gradle.kts
+++ b/modulecheck-core/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
   api(project(path = ":modulecheck-parsing:xml"))
   api(project(path = ":modulecheck-reporting:checkstyle"))
   api(project(path = ":modulecheck-reporting:console"))
+  api(project(path = ":modulecheck-reporting:graphviz"))
 
   implementation(libs.agp)
   implementation(libs.groovy)
@@ -41,5 +42,8 @@ dependencies {
   testImplementation(libs.bundles.kotest)
   testImplementation(libs.kotlin.reflect)
 
+  testImplementation(testFixtures(project(path = ":modulecheck-api")))
+
   testImplementation(project(path = ":modulecheck-internal-testing"))
+  testImplementation(project(path = ":modulecheck-specs"))
 }

--- a/modulecheck-core/build.gradle.kts
+++ b/modulecheck-core/build.gradle.kts
@@ -30,7 +30,6 @@ dependencies {
   api(project(path = ":modulecheck-parsing:xml"))
   api(project(path = ":modulecheck-reporting:checkstyle"))
   api(project(path = ":modulecheck-reporting:console"))
-  api(project(path = ":modulecheck-reporting:graphviz"))
 
   implementation(libs.agp)
   implementation(libs.groovy)

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/CheckstyleReportingTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/CheckstyleReportingTest.kt
@@ -18,6 +18,7 @@ package modulecheck.core
 import modulecheck.api.Finding.FindingResult
 import modulecheck.api.Finding.Position
 import modulecheck.api.PrintLogger
+import modulecheck.api.test.TestSettings
 import modulecheck.core.anvil.CouldUseAnvilFinding
 import modulecheck.reporting.checkstyle.CheckstyleReporter
 import modulecheck.reporting.console.ReportFactory

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/TextReportingTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/TextReportingTest.kt
@@ -17,6 +17,7 @@ package modulecheck.core
 
 import modulecheck.api.Finding
 import modulecheck.api.PrintLogger
+import modulecheck.api.test.TestSettings
 import modulecheck.core.anvil.CouldUseAnvilFinding
 import modulecheck.reporting.checkstyle.CheckstyleReporter
 import modulecheck.reporting.console.ReportFactory


### PR DESCRIPTION
This will grow in time.  The idea is to introduce a simpler DSL for composing `McProjects` and executing tests against them using `ModuleCheckRunner`, without using the full-blown Gradle TestKit.

The intended usage is something like this:

```kotlin
class MyTest : ProjectTest() {

  @Test fun `my test`() {
    val root = project(":") {

      val lib1 = childProject(":lib1") {}

      val lib2 = childProject(":lib2") {
        addDependency(ConfigurationName.implementation, lib1)
      }

      val app = childProject(":app") {
        addDependency(ConfigurationName.implementation, lib1)
        addDependency(ConfigurationName.api, lib2)
      }

      lib1.addDependency(ConfigurationName("testImplementation"), app)
    }

  val runner = ModuleCheckRunner( /* ... */ )
  val result = runner.run(allProjects())

  ...
}
```