### PR TITLE
fix adding redundant configured inherited dependencies

### DIFF
--- a/modulecheck-core/src/main/kotlin/modulecheck/core/rule/InheritedDependencyRule.kt
+++ b/modulecheck-core/src/main/kotlin/modulecheck/core/rule/InheritedDependencyRule.kt
@@ -70,23 +70,23 @@ class InheritedDependencyRule : ModuleCheckRule<InheritedDependencyFinding> {
     // used in `main`, the function will stop there instead of returning a list of `main`, `debug`,
     // `test`, etc.
     suspend fun List<TransitiveProjectDependency>.allUsed(): List<TransitiveProjectDependency> {
-      return fold(listOf()) { acc, transitiveProjectDependency ->
+      return foldRight(listOf()) { transitiveProjectDependency, alreadyUsed ->
 
         val contributedSourceSet = transitiveProjectDependency.contributed
           .configurationName
           .toSourceSetName()
 
-        val alreadyUsedUpstream = acc.any {
+        val alreadyUsedUpstream = alreadyUsed.any {
           val usedSourceSet = it.contributed.configurationName.toSourceSetName()
           contributedSourceSet.inheritsFrom(usedSourceSet, project)
         }
 
         when {
-          alreadyUsedUpstream -> acc
+          alreadyUsedUpstream -> alreadyUsed
           project.uses(transitiveProjectDependency.contributed) -> {
-            acc + transitiveProjectDependency
+            alreadyUsed + transitiveProjectDependency
           }
-          else -> acc
+          else -> alreadyUsed
         }
       }
     }

--- a/modulecheck-parsing/gradle/src/main/kotlin/modulecheck/parsing/gradle/InvokesConfigurationNames.kt
+++ b/modulecheck-parsing/gradle/src/main/kotlin/modulecheck/parsing/gradle/InvokesConfigurationNames.kt
@@ -45,6 +45,7 @@ interface HasPath {
 }
 
 interface HasConfigurations {
+  val sourceSets: SourceSets
   val configurations: Configurations
 }
 
@@ -58,6 +59,12 @@ interface HasConfigurations {
  */
 fun HasConfigurations.inheritingConfigurations(configurationName: ConfigurationName): Set<Config> {
   return configurations.values
+    .asSequence()
+    .map { it.name.toSourceSetName() }
+    .flatMap { sourceSet ->
+      sourceSet.javaConfigurationNames()
+        .mapNotNull { configName -> configurations[configName] }
+    }
     .filter { inheritingConfig ->
       inheritingConfig.inherited
         .any { inheritedConfig ->

--- a/modulecheck-parsing/gradle/src/main/kotlin/modulecheck/parsing/gradle/SourceSet.kt
+++ b/modulecheck-parsing/gradle/src/main/kotlin/modulecheck/parsing/gradle/SourceSet.kt
@@ -94,12 +94,15 @@ value class SourceSetName(val value: String) {
     other: SourceSetName,
     hasConfigurations: HasConfigurations
   ): Boolean {
-    return other.javaConfigurationNames()
-      .any { otherConfig ->
-        hasConfigurations.configurations[otherConfig]
-          ?.inherited
-          ?.any { it.name.toSourceSetName() == this }
-          ?: false
+
+    val otherConfigNames = other.javaConfigurationNames()
+
+    return javaConfigurationNames()
+      .asSequence()
+      .mapNotNull { hasConfigurations.configurations[it] }
+      .map { config -> config.inherited.mapToSet { it.name } }
+      .any { inheritedNames ->
+        inheritedNames.any { inherited -> inherited in otherConfigNames }
       }
   }
 

--- a/modulecheck-plugin/src/main/kotlin/modulecheck/gradle/GradleProjectProvider.kt
+++ b/modulecheck-plugin/src/main/kotlin/modulecheck/gradle/GradleProjectProvider.kt
@@ -184,8 +184,10 @@ class GradleProjectProvider @AssistedInject constructor(
 
     fun Configuration.toConfig(): Config {
 
-      return Config(name = name.asConfigurationName(),
-        inherited = allInherited().mapToSet { it.toConfig() })
+      return Config(
+        name = name.asConfigurationName(),
+        inherited = allInherited().mapToSet { it.toConfig() }
+      )
     }
 
     val map = configurations

--- a/modulecheck-project/api/src/main/kotlin/modulecheck/project/McProject.kt
+++ b/modulecheck-project/api/src/main/kotlin/modulecheck/project/McProject.kt
@@ -22,7 +22,6 @@ import modulecheck.parsing.gradle.HasPath
 import modulecheck.parsing.gradle.InvokesConfigurationNames
 import modulecheck.parsing.gradle.PluginAware
 import modulecheck.parsing.gradle.SourceSetName
-import modulecheck.parsing.gradle.SourceSets
 import modulecheck.parsing.source.AnvilGradlePlugin
 import modulecheck.parsing.source.JavaVersion
 import org.jetbrains.kotlin.name.FqName
@@ -46,7 +45,6 @@ interface McProject :
   val projectDependencies: ProjectDependencies
   val externalDependencies: ExternalDependencies
 
-  val sourceSets: SourceSets
   val anvilGradlePlugin: AnvilGradlePlugin?
 
   override val hasAnvil: Boolean


### PR DESCRIPTION
This bug was never released.

I used `fold` instead of `foldRight` when checking whether a dependency had already been added up-stream, so the check always failed and redundant dependencies were added.

Given this initial state:
```kotlin
dependencies {
  api(project(":lib2"))
}
```
If `:lib2` exposes `:lib1`, and `:lib1` is used explicitly in both `main` and `debug` source sets, the correct auto-corrected block should be this:

```kotlin
dependencies {
  api(project(":lib1"))
  api(project(":lib2"))
}
```

But instead, the `InheritedDependencyRule` was generating this:

```kotlin
dependencies {
  api(project(":lib1"))
  "debugApi"(project(":lib1"))
  api(project(":lib2"))
}
```