### PR TITLE
auto enable `hasTestFixturesPlugin` in tests when adding `testFixtures` source

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -7,13 +7,14 @@
     <inspection_tool class="FunctionName" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <option name="namePattern" value="[`|A-Za-z][A-Za-z\d]*" />
     </inspection_tool>
+    <inspection_tool class="IncorrectFormatting" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
     <inspection_tool class="MemberVisibilityCanBePrivate" enabled="true" level="INFO" enabled_by_default="true">
       <scope name="Tests" level="INFO" enabled="false" />
     </inspection_tool>
     <inspection_tool class="PrivatePropertyName" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <scope name="Tests" level="WEAK WARNING" enabled="true" />
     </inspection_tool>
-    <inspection_tool class="Reformat" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="Reformat" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="RemoveRedundantBackticks" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>

--- a/modulecheck-project/api/src/testFixtures/kotlin/modulecheck/project/test/AndroidMcProjectBuilderScope.kt
+++ b/modulecheck-project/api/src/testFixtures/kotlin/modulecheck/project/test/AndroidMcProjectBuilderScope.kt
@@ -63,7 +63,7 @@ interface AndroidMcProjectBuilderScope : McProjectBuilderScope {
 
     val file = File(projectDir, "src/${sourceSetName.value}/res/$name").createSafely(content)
 
-    val old = sourceSets.getOrPut(sourceSetName) { SourceSet(sourceSetName) }
+    val old = maybeAddSourceSet(sourceSetName)
 
     sourceSets[sourceSetName] = old.copy(resourceFiles = old.resourceFiles + file)
   }
@@ -76,7 +76,7 @@ interface AndroidMcProjectBuilderScope : McProjectBuilderScope {
   ) {
     val file = File(projectDir, "src/${sourceSetName.value}/res/layout/$name").createSafely(content)
 
-    val old = sourceSets.getOrPut(sourceSetName) { SourceSet(sourceSetName) }
+    val old = maybeAddSourceSet(sourceSetName)
 
     sourceSets[sourceSetName] = old.copy(layoutFiles = old.layoutFiles + file)
   }


### PR DESCRIPTION
Without this, it obviously needs to be added manually.  If it's not enabled manually, then any auto-corrected `testFixtures` dependencies in `.kts` build files get `"testFixtures____(...)"` configs instead of `testFixtures____(...)`.