### PR TITLE
Add a test case for false positive

### DIFF
--- a/modulecheck-parsing/gradle/build.gradle.kts
+++ b/modulecheck-parsing/gradle/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
   api(libs.rickBusarow.dispatch.core)
   api(libs.semVer)
 
+  api(project(path = ":modulecheck-parsing:source"))
   api(project(path = ":modulecheck-utils"))
 
   compileOnly(gradleApi())

--- a/modulecheck-parsing/gradle/src/main/kotlin/modulecheck/parsing/gradle/PlatformPlugin.kt
+++ b/modulecheck-parsing/gradle/src/main/kotlin/modulecheck/parsing/gradle/PlatformPlugin.kt
@@ -15,6 +15,7 @@
 
 package modulecheck.parsing.gradle
 
+import modulecheck.parsing.source.UnqualifiedAndroidResourceDeclaredName
 import java.io.File
 import kotlin.contracts.contract
 
@@ -61,6 +62,7 @@ sealed interface AndroidPlatformPlugin : PlatformPlugin {
   val viewBindingEnabled: Boolean
   val kotlinAndroidExtensionEnabled: Boolean
   val manifests: Map<SourceSetName, File>
+  val resValues: Map<SourceSetName, Set<UnqualifiedAndroidResourceDeclaredName>>
 
   interface CanDisableAndroidResources {
     val androidResourcesEnabled: Boolean
@@ -76,7 +78,8 @@ sealed interface AndroidPlatformPlugin : PlatformPlugin {
     override val nonTransientRClass: Boolean,
     override val viewBindingEnabled: Boolean,
     override val kotlinAndroidExtensionEnabled: Boolean,
-    override val manifests: Map<SourceSetName, File>
+    override val manifests: Map<SourceSetName, File>,
+    override val resValues: Map<SourceSetName, Set<UnqualifiedAndroidResourceDeclaredName>>
   ) : PlatformPlugin, AndroidPlatformPlugin
 
   data class AndroidLibraryPlugin(
@@ -87,7 +90,8 @@ sealed interface AndroidPlatformPlugin : PlatformPlugin {
     override val kotlinAndroidExtensionEnabled: Boolean,
     override val manifests: Map<SourceSetName, File>,
     override val androidResourcesEnabled: Boolean,
-    override val buildConfigEnabled: Boolean
+    override val buildConfigEnabled: Boolean,
+    override val resValues: Map<SourceSetName, Set<UnqualifiedAndroidResourceDeclaredName>>
   ) : PlatformPlugin,
     AndroidPlatformPlugin,
     CanDisableAndroidResources,
@@ -100,7 +104,8 @@ sealed interface AndroidPlatformPlugin : PlatformPlugin {
     override val viewBindingEnabled: Boolean,
     override val kotlinAndroidExtensionEnabled: Boolean,
     override val manifests: Map<SourceSetName, File>,
-    override val buildConfigEnabled: Boolean
+    override val buildConfigEnabled: Boolean,
+    override val resValues: Map<SourceSetName, Set<UnqualifiedAndroidResourceDeclaredName>>
   ) : PlatformPlugin,
     AndroidPlatformPlugin,
     CanDisableAndroidBuildConfig
@@ -112,7 +117,8 @@ sealed interface AndroidPlatformPlugin : PlatformPlugin {
     override val viewBindingEnabled: Boolean,
     override val kotlinAndroidExtensionEnabled: Boolean,
     override val manifests: Map<SourceSetName, File>,
-    override val buildConfigEnabled: Boolean
+    override val buildConfigEnabled: Boolean,
+    override val resValues: Map<SourceSetName, Set<UnqualifiedAndroidResourceDeclaredName>>
   ) : PlatformPlugin,
     AndroidPlatformPlugin,
     CanDisableAndroidBuildConfig

--- a/modulecheck-plugin/src/test/kotlin/modulecheck/gradle/UnusedDependenciesPluginTest.kt
+++ b/modulecheck-plugin/src/test/kotlin/modulecheck/gradle/UnusedDependenciesPluginTest.kt
@@ -26,6 +26,7 @@ import modulecheck.specs.ProjectBuildSpecBuilder
 import modulecheck.specs.ProjectSettingsSpecBuilder
 import modulecheck.specs.ProjectSpec
 import modulecheck.specs.ProjectSrcSpec
+import modulecheck.specs.ProjectSrcSpecBuilder.RawFile
 import modulecheck.utils.applyEach
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -327,7 +328,7 @@ class UnusedDependenciesPluginTest : BasePluginTest() {
             RawFile(
               "AndroidManifest.xml",
               """<manifest package="com.example.app" />
-                """.trimMargin()
+              """.trimMargin()
             )
           )
         }
@@ -343,12 +344,17 @@ class UnusedDependenciesPluginTest : BasePluginTest() {
           android = true
           addBlock(
             """
-          |android {
-          |  defaultConfig {
-          |    resValue("string", "app_name", "AppName")
-          |  }
-          |}
-          """.trimMargin()
+            android {
+              defaultConfig {
+                resValue("string", "app_name", "AppName")
+              }
+              buildTypes {
+                getByName("debug") {
+                  resValue("string", "debug_thing", "debug!")
+                }
+              }
+            }
+            """
           )
         }
       )

--- a/modulecheck-project/api/src/testFixtures/kotlin/modulecheck/project/test/PlatformPluginBuilder.kt
+++ b/modulecheck-project/api/src/testFixtures/kotlin/modulecheck/project/test/PlatformPluginBuilder.kt
@@ -27,6 +27,7 @@ import modulecheck.parsing.gradle.JvmPlatformPlugin.KotlinJvmPlugin
 import modulecheck.parsing.gradle.PlatformPlugin
 import modulecheck.parsing.gradle.SourceSetName
 import modulecheck.parsing.gradle.SourceSets
+import modulecheck.parsing.source.UnqualifiedAndroidResourceDeclaredName
 import java.io.File
 
 interface PlatformPluginBuilder<T : PlatformPlugin> {
@@ -62,6 +63,7 @@ interface AndroidPlatformPluginBuilder<T : AndroidPlatformPlugin> : PlatformPlug
   var nonTransientRClass: Boolean
   var kotlinAndroidExtensionEnabled: Boolean
   val manifests: MutableMap<SourceSetName, File>
+  val resValues: MutableMap<SourceSetName, Set<UnqualifiedAndroidResourceDeclaredName>>
 }
 
 data class AndroidApplicationPluginBuilder(
@@ -70,7 +72,8 @@ data class AndroidApplicationPluginBuilder(
   override var kotlinAndroidExtensionEnabled: Boolean = true,
   override val manifests: MutableMap<SourceSetName, File> = mutableMapOf(),
   override val sourceSets: MutableMap<SourceSetName, SourceSetBuilder> = mutableMapOf(),
-  override val configurations: MutableMap<ConfigurationName, ConfigBuilder> = mutableMapOf()
+  override val configurations: MutableMap<ConfigurationName, ConfigBuilder> = mutableMapOf(),
+  override val resValues: MutableMap<SourceSetName, Set<UnqualifiedAndroidResourceDeclaredName>> = mutableMapOf()
 ) : AndroidPlatformPluginBuilder<AndroidApplicationPlugin> {
   override fun toPlugin(): AndroidApplicationPlugin = AndroidApplicationPlugin(
     sourceSets = SourceSets(sourceSets.mapValues { it.value.toSourceSet() }),
@@ -78,7 +81,8 @@ data class AndroidApplicationPluginBuilder(
     nonTransientRClass = nonTransientRClass,
     viewBindingEnabled = viewBindingEnabled,
     kotlinAndroidExtensionEnabled = kotlinAndroidExtensionEnabled,
-    manifests = manifests
+    manifests = manifests,
+    resValues = resValues
   )
 }
 
@@ -90,7 +94,8 @@ data class AndroidLibraryPluginBuilder(
   var androidResourcesEnabled: Boolean = true,
   override val manifests: MutableMap<SourceSetName, File> = mutableMapOf(),
   override val sourceSets: MutableMap<SourceSetName, SourceSetBuilder> = mutableMapOf(),
-  override val configurations: MutableMap<ConfigurationName, ConfigBuilder> = mutableMapOf()
+  override val configurations: MutableMap<ConfigurationName, ConfigBuilder> = mutableMapOf(),
+  override val resValues: MutableMap<SourceSetName, Set<UnqualifiedAndroidResourceDeclaredName>> = mutableMapOf()
 ) : AndroidPlatformPluginBuilder<AndroidLibraryPlugin> {
   override fun toPlugin(): AndroidLibraryPlugin = AndroidLibraryPlugin(
     sourceSets = SourceSets(sourceSets.mapValues { it.value.toSourceSet() }),
@@ -100,7 +105,8 @@ data class AndroidLibraryPluginBuilder(
     kotlinAndroidExtensionEnabled = kotlinAndroidExtensionEnabled,
     manifests = manifests,
     androidResourcesEnabled = androidResourcesEnabled,
-    buildConfigEnabled = buildConfigEnabled
+    buildConfigEnabled = buildConfigEnabled,
+    resValues = resValues
   )
 }
 
@@ -111,7 +117,8 @@ data class AndroidDynamicFeaturePluginBuilder(
   var buildConfigEnabled: Boolean = true,
   override val manifests: MutableMap<SourceSetName, File> = mutableMapOf(),
   override val sourceSets: MutableMap<SourceSetName, SourceSetBuilder> = mutableMapOf(),
-  override val configurations: MutableMap<ConfigurationName, ConfigBuilder> = mutableMapOf()
+  override val configurations: MutableMap<ConfigurationName, ConfigBuilder> = mutableMapOf(),
+  override val resValues: MutableMap<SourceSetName, Set<UnqualifiedAndroidResourceDeclaredName>> = mutableMapOf()
 ) : AndroidPlatformPluginBuilder<AndroidDynamicFeaturePlugin> {
   override fun toPlugin(): AndroidDynamicFeaturePlugin = AndroidDynamicFeaturePlugin(
     sourceSets = SourceSets(sourceSets.mapValues { it.value.toSourceSet() }),
@@ -120,7 +127,8 @@ data class AndroidDynamicFeaturePluginBuilder(
     viewBindingEnabled = viewBindingEnabled,
     kotlinAndroidExtensionEnabled = kotlinAndroidExtensionEnabled,
     manifests = manifests,
-    buildConfigEnabled = buildConfigEnabled
+    buildConfigEnabled = buildConfigEnabled,
+    resValues = resValues
   )
 }
 
@@ -131,7 +139,8 @@ data class AndroidTestPluginBuilder(
   var buildConfigEnabled: Boolean = true,
   override val manifests: MutableMap<SourceSetName, File> = mutableMapOf(),
   override val sourceSets: MutableMap<SourceSetName, SourceSetBuilder> = mutableMapOf(),
-  override val configurations: MutableMap<ConfigurationName, ConfigBuilder> = mutableMapOf()
+  override val configurations: MutableMap<ConfigurationName, ConfigBuilder> = mutableMapOf(),
+  override val resValues: MutableMap<SourceSetName, Set<UnqualifiedAndroidResourceDeclaredName>> = mutableMapOf()
 ) : AndroidPlatformPluginBuilder<AndroidTestPlugin> {
   override fun toPlugin(): AndroidTestPlugin = AndroidTestPlugin(
     sourceSets = SourceSets(sourceSets.mapValues { it.value.toSourceSet() }),
@@ -140,6 +149,7 @@ data class AndroidTestPluginBuilder(
     viewBindingEnabled = viewBindingEnabled,
     kotlinAndroidExtensionEnabled = kotlinAndroidExtensionEnabled,
     manifests = manifests,
-    buildConfigEnabled = buildConfigEnabled
+    buildConfigEnabled = buildConfigEnabled,
+    resValues = resValues
   )
 }


### PR DESCRIPTION
There was one false-positive in our project. Instead of opening an issue, I thought it would be better to have a failing test case. 

If a dependant module uses `resValue`, then the generated resource usage is not detected.