### PR TITLE
remove `trimmedShouldBe` from failed test stacktraces

### DIFF
--- a/modulecheck-internal-testing/src/main/kotlin/modulecheck/testing/BaseTest.kt
+++ b/modulecheck-internal-testing/src/main/kotlin/modulecheck/testing/BaseTest.kt
@@ -133,7 +133,10 @@ infix fun <T, U : T> T.trimmedShouldBe(expected: U?) {
     @Suppress("MagicNumber")
     assertionError.stackTrace = assertionError
       .stackTrace
-      .filterNot { it.className == BaseTest::class.qualifiedName }
+      .dropWhile {
+        it.className == BaseTest::class.qualifiedName ||
+          it.className == "${BaseTest::class.qualifiedName}Kt"
+      }
       .take(5) // keep stack traces short
       .toTypedArray()
     throw assertionError


### PR DESCRIPTION
Stacktraces currently look like this:

```
	at app//modulecheck.testing.BaseTestKt.trimmedShouldBe(BaseTest.kt:130)
	at app//modulecheck.core.DisableAndroidResourcesTest.resource generation is used in contributing module with no changes(DisableAndroidResourcesTest.kt:76)
	at java.base@11.0.13/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base@11.0.13/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base@11.0.13/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
```

That first call to `trimmedShouldBe` is supposed to be filtering itself out of the stacktrace, but it isn't working because it's filtering by the class name (`BaseTest`) and this function became an extension with the class name of `BaseTestKt`.