### PR TITLE
Resolve references in test projects

### DIFF
--- a/modulecheck-api/src/main/kotlin/modulecheck/api/context/Declarations.kt
+++ b/modulecheck-api/src/main/kotlin/modulecheck/api/context/Declarations.kt
@@ -28,6 +28,7 @@ import modulecheck.utils.LazySet.DataSource
 import modulecheck.utils.LazySet.DataSource.Priority.HIGH
 import modulecheck.utils.SafeCache
 import modulecheck.utils.dataSource
+import modulecheck.utils.emptyDataSource
 import modulecheck.utils.lazySet
 
 data class Declarations(
@@ -37,6 +38,13 @@ data class Declarations(
 
   override val key: ProjectContext.Key<Declarations>
     get() = Key
+
+  suspend fun all(): LazySet<DeclarationName> {
+    return project.sourceSets
+      .keys
+      .map { project.declarations().get(it) }
+      .let { lazySet(it, emptyDataSource()) }
+  }
 
   suspend fun get(sourceSetName: SourceSetName): LazySet<DeclarationName> {
     return delegate.getOrPut(sourceSetName) {

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/CheckstyleReportingTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/CheckstyleReportingTest.kt
@@ -38,7 +38,7 @@ internal class CheckstyleReportingTest : RunnerTest() {
 
     val outputFile = File(settings.reports.checkstyle.outputPath)
 
-    val runner = runner(
+    run(
       autoCorrect = false,
       findingFactory = findingFactory(
         listOf(
@@ -63,11 +63,7 @@ internal class CheckstyleReportingTest : RunnerTest() {
           )
         )
       }
-    )
-
-    val result = runner.run(listOf())
-
-    result.isSuccess shouldBe true
+    ).isSuccess shouldBe true
 
     outputFile.exists() shouldBe false
   }
@@ -79,7 +75,7 @@ internal class CheckstyleReportingTest : RunnerTest() {
 
     val outputFile = File(settings.reports.checkstyle.outputPath)
 
-    val runner = runner(
+    run(
       autoCorrect = false,
       findingFactory = findingFactory(
         listOf(
@@ -104,11 +100,7 @@ internal class CheckstyleReportingTest : RunnerTest() {
           )
         }
       }
-    )
-
-    val result = runner.run(listOf())
-
-    result.isSuccess shouldBe true
+    ).isSuccess shouldBe true
 
     outputFile.readText() shouldBe """
       <?xml version="1.0" encoding="UTF-8"?>

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/ConsoleReportingTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/ConsoleReportingTest.kt
@@ -16,7 +16,8 @@
 package modulecheck.core
 
 import io.kotest.matchers.string.shouldContain
-import modulecheck.api.finding.Finding
+import modulecheck.api.finding.Finding.FindingResult
+import modulecheck.api.finding.Finding.Position
 import modulecheck.core.anvil.CouldUseAnvilFinding
 import modulecheck.runtime.test.RunnerTest
 import modulecheck.utils.remove
@@ -28,12 +29,10 @@ internal class ConsoleReportingTest : RunnerTest() {
   @Test
   fun `zero findings should report '0 issues' to console`() {
 
-    val runner = runner(
+    run(
       autoCorrect = false,
       findingFactory = findingFactory()
     )
-
-    runner.run(listOf())
 
     logger.collectReport()
       .joinToString()
@@ -44,7 +43,7 @@ internal class ConsoleReportingTest : RunnerTest() {
   @Test
   fun `one finding should report '1 issue' to console`() {
 
-    val runner = runner(
+    run(
       autoCorrect = false,
       findingFactory = findingFactory(
         listOf(
@@ -55,8 +54,6 @@ internal class ConsoleReportingTest : RunnerTest() {
         )
       )
     )
-
-    runner.run(listOf())
 
     logger.collectReport()
       .joinToString()
@@ -73,7 +70,7 @@ internal class ConsoleReportingTest : RunnerTest() {
   @Test
   fun `multiple findings should report 'n issues' to console`() {
 
-    val runner = runner(
+    run(
       autoCorrect = false,
       findingFactory = findingFactory(
         listOf(
@@ -88,8 +85,6 @@ internal class ConsoleReportingTest : RunnerTest() {
         )
       )
     )
-
-    runner.run(listOf())
 
     logger.collectReport()
       .joinToString()
@@ -110,7 +105,7 @@ internal class ConsoleReportingTest : RunnerTest() {
   @Test
   fun `non-zero findings should print suppression advice to console`() {
 
-    val runner = runner(
+    run(
       autoCorrect = false,
       findingFactory = findingFactory(
         listOf(
@@ -121,8 +116,6 @@ internal class ConsoleReportingTest : RunnerTest() {
         )
       )
     )
-
-    runner.run(listOf())
 
     logger.collectReport()
       .joinToString() shouldContain "To ignore any of these findings, " +
@@ -135,18 +128,16 @@ internal class ConsoleReportingTest : RunnerTest() {
   @Test
   fun `zero findings should succeed`() {
 
-    val runner = runner(
+    run(
       autoCorrect = false,
       findingFactory = findingFactory()
-    )
-
-    runner.run(listOf()).isSuccess shouldBe true
+    ).isSuccess shouldBe true
   }
 
   @Test
   fun `all findings fixed should succeed`() {
 
-    val runner = runner(
+    run(
       autoCorrect = false,
       findingFactory = findingFactory(
         listOf(
@@ -158,28 +149,26 @@ internal class ConsoleReportingTest : RunnerTest() {
       ),
       findingResultFactory = { _, _, _ ->
         listOf(
-          Finding.FindingResult(
+          FindingResult(
             dependentPath = "dependentPath",
             problemName = "problemName",
             sourceOrNull = "sourceOrNull",
             configurationName = "configurationName",
             dependencyPath = "dependencyPath",
-            positionOrNull = Finding.Position(1, 2),
+            positionOrNull = Position(1, 2),
             buildFile = File("buildFile"),
             message = "message",
             fixed = true
           )
         )
       }
-    )
-
-    runner.run(listOf()).isSuccess shouldBe true
+    ).isSuccess shouldBe true
   }
 
   @Test
   fun `non-zero unfixed findings should fail`() {
 
-    val runner = runner(
+    run(
       autoCorrect = false,
       findingFactory = findingFactory(
         listOf(
@@ -191,21 +180,19 @@ internal class ConsoleReportingTest : RunnerTest() {
       ),
       findingResultFactory = { _, _, _ ->
         listOf(
-          Finding.FindingResult(
+          FindingResult(
             dependentPath = "dependentPath",
             problemName = "problemName",
             sourceOrNull = "sourceOrNull",
             configurationName = "configurationName",
             dependencyPath = "dependencyPath",
-            positionOrNull = Finding.Position(1, 2),
+            positionOrNull = Position(1, 2),
             buildFile = File("buildFile"),
             message = "message",
             fixed = false
           )
         )
       }
-    )
-
-    runner.run(listOf()).isFailure shouldBe true
+    ).isFailure shouldBe true
   }
 }

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/DepthOutputTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/DepthOutputTest.kt
@@ -16,7 +16,6 @@
 package modulecheck.core
 
 import modulecheck.core.rule.DepthRule
-import modulecheck.core.rule.ModuleCheckRuleFactory
 import modulecheck.core.rule.MultiRuleFindingFactory
 import modulecheck.core.rule.SingleRuleFindingFactory
 import modulecheck.parsing.gradle.ConfigurationName
@@ -26,9 +25,7 @@ import org.junit.jupiter.api.Test
 
 internal class DepthOutputTest : RunnerTest() {
 
-  val ruleFactory by resets { ModuleCheckRuleFactory() }
-
-  val findingFactory by resets { SingleRuleFindingFactory(DepthRule()) }
+  override val findingFactory by resets { SingleRuleFindingFactory(DepthRule()) }
 
   @Test
   fun `main source set depths should be reported`() {

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/DepthOutputTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/DepthOutputTest.kt
@@ -30,11 +30,6 @@ internal class DepthOutputTest : RunnerTest() {
   @Test
   fun `main source set depths should be reported`() {
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1")
 
     val lib2 = project(":lib2") {
@@ -46,7 +41,10 @@ internal class DepthOutputTest : RunnerTest() {
       addDependency(ConfigurationName.implementation, lib2)
     }
 
-    runner.run(allProjects())
+    run(
+      autoCorrect = false,
+      findingFactory = findingFactory
+    )
 
     logger.collectReport()
       .joinToString()
@@ -66,14 +64,6 @@ internal class DepthOutputTest : RunnerTest() {
 
     settings.checks.depths = true
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = MultiRuleFindingFactory(
-        settings,
-        ruleFactory.create(settings)
-      )
-    )
-
     val lib1 = project(":lib1")
 
     project(":lib2") {
@@ -92,7 +82,12 @@ internal class DepthOutputTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run(
+      findingFactory = MultiRuleFindingFactory(
+        settings,
+        ruleFactory.create(settings)
+      )
+    ).isSuccess shouldBe true
 
     logger.collectReport()
       .joinToString()
@@ -113,11 +108,6 @@ internal class DepthOutputTest : RunnerTest() {
   @Test
   fun `test source set depths should not be reported`() {
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1")
 
     val lib2 = project(":lib2") {
@@ -131,7 +121,10 @@ internal class DepthOutputTest : RunnerTest() {
 
     lib1.addDependency(ConfigurationName("testImplementation"), lib2)
 
-    runner.run(allProjects())
+    run(
+      autoCorrect = false,
+      findingFactory = findingFactory
+    )
 
     logger.collectReport()
       .joinToString()
@@ -148,11 +141,6 @@ internal class DepthOutputTest : RunnerTest() {
 
   @Test
   fun `debug source set depth should not be reported even if it's longer`() {
-
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1")
     val debug1 = project(":debug1") {}
@@ -171,7 +159,10 @@ internal class DepthOutputTest : RunnerTest() {
       addDependency(ConfigurationName("debugImplementation"), debug2)
     }
 
-    runner.run(allProjects())
+    run(
+      autoCorrect = false,
+      findingFactory = findingFactory
+    )
 
     logger.collectReport()
       .joinToString()

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/DepthReportTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/DepthReportTest.kt
@@ -17,7 +17,6 @@ package modulecheck.core
 
 import modulecheck.api.test.TestSettings
 import modulecheck.core.rule.DepthRule
-import modulecheck.core.rule.ModuleCheckRuleFactory
 import modulecheck.core.rule.MultiRuleFindingFactory
 import modulecheck.core.rule.SingleRuleFindingFactory
 import modulecheck.parsing.gradle.ConfigurationName
@@ -31,14 +30,12 @@ import java.io.File
 
 internal class DepthReportTest : RunnerTest() {
 
-  val ruleFactory by resets { ModuleCheckRuleFactory() }
-
   override val settings by resets {
     TestSettings().apply {
       reports.depths.outputPath = File(testProjectDir, reports.depths.outputPath).path
     }
   }
-  val findingFactory by resets { SingleRuleFindingFactory(DepthRule()) }
+  override val findingFactory by resets { SingleRuleFindingFactory(DepthRule()) }
 
   val outputFile by resets { File(settings.reports.depths.outputPath) }
 

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/DepthReportTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/DepthReportTest.kt
@@ -44,11 +44,6 @@ internal class DepthReportTest : RunnerTest() {
 
     settings.reports.depths.enabled = false
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1")
 
     val lib2 = project(":lib2") {
@@ -60,9 +55,7 @@ internal class DepthReportTest : RunnerTest() {
       addDependency(ConfigurationName.implementation, lib2)
     }
 
-    val result = runner.run(allProjects())
-
-    result.isSuccess shouldBe true
+    run(autoCorrect = false).isSuccess shouldBe true
 
     outputFile.exists() shouldBe false
   }
@@ -72,11 +65,6 @@ internal class DepthReportTest : RunnerTest() {
 
     settings.reports.depths.enabled = true
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1")
 
     val lib2 = project(":lib2") {
@@ -88,9 +76,7 @@ internal class DepthReportTest : RunnerTest() {
       addDependency(ConfigurationName.implementation, lib2)
     }
 
-    val result = runner.run(allProjects())
-
-    result.isSuccess shouldBe true
+    run(autoCorrect = false).isSuccess shouldBe true
 
     outputFile.readText() shouldBe """
       -- ModuleCheck Depth results --
@@ -111,11 +97,6 @@ internal class DepthReportTest : RunnerTest() {
 
     settings.reports.depths.enabled = true
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1") {
 
       val myFile = File(projectDir, "src/main/kotlin/MyFile.kt").createSafely()
@@ -135,9 +116,7 @@ internal class DepthReportTest : RunnerTest() {
       addDependency(ConfigurationName.implementation, lib2)
     }
 
-    val result = runner.run(allProjects())
-
-    result.isSuccess shouldBe true
+    run(autoCorrect = false).isSuccess shouldBe true
 
     outputFile.readText() shouldBe """
       -- ModuleCheck Depth results --
@@ -162,11 +141,6 @@ internal class DepthReportTest : RunnerTest() {
 
     settings.reports.depths.enabled = true
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1") {
       sourceSets[SourceSetName.MAIN] = SourceSet(name = SourceSetName.MAIN)
     }
@@ -180,9 +154,7 @@ internal class DepthReportTest : RunnerTest() {
       addDependency(ConfigurationName.implementation, lib2)
     }
 
-    val result = runner.run(allProjects())
-
-    result.isSuccess shouldBe true
+    run(autoCorrect = false).isSuccess shouldBe true
 
     outputFile.readText() shouldBe """
       -- ModuleCheck Depth results --
@@ -203,11 +175,6 @@ internal class DepthReportTest : RunnerTest() {
 
     settings.reports.depths.enabled = true
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1") {
       addSourceSet(SourceSetName.TEST)
     }
@@ -223,9 +190,7 @@ internal class DepthReportTest : RunnerTest() {
 
     lib1.addDependency(ConfigurationName("testImplementation"), lib2)
 
-    val result = runner.run(allProjects())
-
-    result.isSuccess shouldBe true
+    run(autoCorrect = false).isSuccess shouldBe true
 
     outputFile.readText() shouldBe """
       -- ModuleCheck Depth results --
@@ -250,14 +215,6 @@ internal class DepthReportTest : RunnerTest() {
 
     settings.checks.depths = true
     settings.reports.depths.enabled = true
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = MultiRuleFindingFactory(
-        settings,
-        ruleFactory.create(settings)
-      )
-    )
 
     val lib1 = project(":lib1") {
 
@@ -316,7 +273,12 @@ internal class DepthReportTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run(
+      findingFactory = MultiRuleFindingFactory(
+        settings,
+        ruleFactory.create(settings)
+      )
+    ).isSuccess shouldBe true
 
     logger.collectReport()
       .joinToString()
@@ -357,11 +319,6 @@ internal class DepthReportTest : RunnerTest() {
 
     settings.reports.depths.enabled = true
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1")
     val debug1 = project(":debug1") {
       addDependency(ConfigurationName.implementation, lib1)
@@ -382,9 +339,7 @@ internal class DepthReportTest : RunnerTest() {
       addDependency(ConfigurationName("debugImplementation"), debug2)
     }
 
-    val result = runner.run(allProjects())
-
-    result.isSuccess shouldBe true
+    run(autoCorrect = false).isSuccess shouldBe true
 
     outputFile.readText() shouldBe """
       -- ModuleCheck Depth results --

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/DisableAndroidResourcesTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/DisableAndroidResourcesTest.kt
@@ -30,11 +30,6 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `resource generation is used in contributing module with no changes`() {
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
         """
@@ -61,7 +56,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run(autoCorrect = false).isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -75,11 +70,6 @@ class DisableAndroidResourcesTest : RunnerTest() {
 
   @Test
   fun `resource generation is used in dependent module with no changes`() {
-
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
 
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
@@ -117,7 +107,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run(autoCorrect = false).isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -136,11 +126,6 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `unused resource generation without autocorrect should fail and be reported`() {
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
         """
@@ -152,7 +137,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe false
+    run(autoCorrect = false).isSuccess shouldBe false
 
     lib1.buildFile.readText() shouldBe """
     plugins {
@@ -171,11 +156,6 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `unused resource generation when scoped and then qualified should be fixed`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
         """
@@ -190,7 +170,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -212,11 +192,6 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `unused resource generation without buildFeatures block should be fixed`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
         """
@@ -232,7 +207,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -256,11 +231,6 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `unused resource generation without android block should add android block under existing plugins block`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
         """
@@ -272,7 +242,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -297,11 +267,6 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `unused resource generation without android or plugins block should add android block above dependencies block`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
         """
@@ -314,7 +279,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       apply(plugin = "com.android.library")
@@ -340,11 +305,6 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `unused resource generation when fully qualified should be fixed`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
         """
@@ -357,7 +317,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -377,11 +337,6 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `unused resource generation when qualified and then scoped should be fixed`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
         """
@@ -396,7 +351,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -418,11 +373,6 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `unused resource generation when fully scoped should be fixed`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
         """
@@ -439,7 +389,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
         plugins {
@@ -463,11 +413,6 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `unused resource generation with autocorrect and no explicit buildFeatures property should be fixed`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
         """
@@ -479,7 +424,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -504,11 +449,6 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `unused resource generation with autocorrect and no android block should be fixed`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
         """
@@ -520,7 +460,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     logger.parsedReport() shouldBe listOf(
       ":lib1" to listOf(

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/DisableAndroidResourcesTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/DisableAndroidResourcesTest.kt
@@ -17,8 +17,6 @@ package modulecheck.core
 
 import modulecheck.api.test.TestChecksSettings
 import modulecheck.api.test.TestSettings
-import modulecheck.core.rule.ModuleCheckRuleFactory
-import modulecheck.core.rule.MultiRuleFindingFactory
 import modulecheck.parsing.gradle.ConfigurationName
 import modulecheck.runtime.test.ProjectFindingReport.disableAndroidResources
 import modulecheck.runtime.test.RunnerTest
@@ -27,15 +25,7 @@ import org.junit.jupiter.api.Test
 
 class DisableAndroidResourcesTest : RunnerTest() {
 
-  val ruleFactory by resets { ModuleCheckRuleFactory() }
-
   override val settings by resets { TestSettings(checks = TestChecksSettings(disableAndroidResources = true)) }
-  val findingFactory by resets {
-    MultiRuleFindingFactory(
-      settings,
-      ruleFactory.create(settings)
-    )
-  }
 
   @Test
   fun `resource generation is used in contributing module with no changes`() {

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/DisableViewBindingTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/DisableViewBindingTest.kt
@@ -33,11 +33,6 @@ class DisableViewBindingTest : RunnerTest() {
   @Test
   fun `used ViewBinding in dependent module with no changes`() {
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
         """
@@ -80,7 +75,9 @@ class DisableViewBindingTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run(
+      autoCorrect = false,
+    ).isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -98,11 +95,6 @@ class DisableViewBindingTest : RunnerTest() {
 
   @Test
   fun `used ViewBinding in contributing module`() {
-
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
 
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
@@ -141,7 +133,9 @@ class DisableViewBindingTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run(
+      autoCorrect = false,
+    ).isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -159,11 +153,6 @@ class DisableViewBindingTest : RunnerTest() {
 
   @Test
   fun `ViewBinding from main is used in debug source set`() {
-
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
 
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
@@ -209,7 +198,9 @@ class DisableViewBindingTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run(
+      autoCorrect = false,
+    ).isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -227,11 +218,6 @@ class DisableViewBindingTest : RunnerTest() {
 
   @Test
   fun `ViewBinding from debug with different base package is used in debug source set`() {
-
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
 
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
@@ -275,7 +261,9 @@ class DisableViewBindingTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run(
+      autoCorrect = false,
+    ).isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -293,11 +281,6 @@ class DisableViewBindingTest : RunnerTest() {
 
   @Test
   fun `ViewBinding from debug without different base package is used in debug source set`() {
-
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
 
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
@@ -341,7 +324,9 @@ class DisableViewBindingTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run(
+      autoCorrect = false,
+    ).isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -362,11 +347,6 @@ class DisableViewBindingTest : RunnerTest() {
 
     settings.checks.disableViewBinding = false
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
         """
@@ -393,7 +373,9 @@ class DisableViewBindingTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run(
+      autoCorrect = false,
+    ).isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -412,11 +394,6 @@ class DisableViewBindingTest : RunnerTest() {
   @Test
   fun `unused ViewBinding without auto-correct should fail`() {
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
         """
@@ -443,7 +420,9 @@ class DisableViewBindingTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe false
+    run(
+      autoCorrect = false,
+    ).isSuccess shouldBe false
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -464,11 +443,6 @@ class DisableViewBindingTest : RunnerTest() {
   @Test
   fun `unused ViewBinding when scoped and then qualified should be fixed`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
         """
@@ -484,7 +458,7 @@ class DisableViewBindingTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -505,11 +479,6 @@ class DisableViewBindingTest : RunnerTest() {
   @Test
   fun `unused ViewBinding without buildFeatures block should be fixed`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
         """
@@ -525,7 +494,7 @@ class DisableViewBindingTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -547,11 +516,6 @@ class DisableViewBindingTest : RunnerTest() {
   @Test
   fun `unused ViewBinding without android block should add android block under existing plugins block`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
         """
@@ -563,7 +527,7 @@ class DisableViewBindingTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -586,11 +550,6 @@ class DisableViewBindingTest : RunnerTest() {
   @Test
   fun `unused ViewBinding without android or plugins block should add android block above dependencies block`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
         """
@@ -603,7 +562,7 @@ class DisableViewBindingTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       apply(plugin = "com.android.library")
@@ -626,11 +585,6 @@ class DisableViewBindingTest : RunnerTest() {
 
   @Test
   fun `unused ViewBinding when fully qualified should be fixed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
@@ -656,7 +610,7 @@ class DisableViewBindingTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -674,11 +628,6 @@ class DisableViewBindingTest : RunnerTest() {
 
   @Test
   fun `unused ViewBinding when fully scoped should be fixed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
@@ -708,7 +657,7 @@ class DisableViewBindingTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
         plugins {
@@ -730,11 +679,6 @@ class DisableViewBindingTest : RunnerTest() {
 
   @Test
   fun `unused ViewBinding when qualified and then scoped should be fixed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       buildFile.writeKotlin(
@@ -762,7 +706,7 @@ class DisableViewBindingTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
         plugins {

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/DisableViewBindingTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/DisableViewBindingTest.kt
@@ -17,8 +17,6 @@ package modulecheck.core
 
 import modulecheck.api.test.TestChecksSettings
 import modulecheck.api.test.TestSettings
-import modulecheck.core.rule.ModuleCheckRuleFactory
-import modulecheck.core.rule.MultiRuleFindingFactory
 import modulecheck.parsing.gradle.ConfigurationName
 import modulecheck.parsing.gradle.SourceSetName
 import modulecheck.runtime.test.ProjectFindingReport.disableViewBinding
@@ -30,15 +28,7 @@ import org.junit.jupiter.api.Test
 
 class DisableViewBindingTest : RunnerTest() {
 
-  val ruleFactory by resets { ModuleCheckRuleFactory() }
-
   override val settings by resets { TestSettings(checks = TestChecksSettings(disableViewBinding = true)) }
-  val findingFactory by resets {
-    MultiRuleFindingFactory(
-      settings,
-      ruleFactory.create(settings)
-    )
-  }
 
   @Test
   fun `used ViewBinding in dependent module with no changes`() {
@@ -69,14 +59,7 @@ class DisableViewBindingTest : RunnerTest() {
           android:id="@+id/fragment_container"
           android:layout_width="match_parent"
           android:layout_height="match_parent"
-          >
-
-          <com.modulecheck.lib1.Lib1View
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
+          />
         """
       )
     }
@@ -142,14 +125,7 @@ class DisableViewBindingTest : RunnerTest() {
           android:id="@+id/fragment_container"
           android:layout_width="match_parent"
           android:layout_height="match_parent"
-          >
-
-          <com.modulecheck.lib1.Lib1View
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
+          />
         """
       )
 
@@ -210,14 +186,7 @@ class DisableViewBindingTest : RunnerTest() {
           android:id="@+id/fragment_container"
           android:layout_width="match_parent"
           android:layout_height="match_parent"
-          >
-
-          <com.modulecheck.lib1.Lib1View
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
+          />
         """
       )
 
@@ -285,14 +254,7 @@ class DisableViewBindingTest : RunnerTest() {
           android:id="@+id/fragment_container"
           android:layout_width="match_parent"
           android:layout_height="match_parent"
-          >
-
-          <com.modulecheck.lib1.Lib1View
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
+          />
         """,
         SourceSetName.DEBUG
       )
@@ -358,14 +320,7 @@ class DisableViewBindingTest : RunnerTest() {
           android:id="@+id/fragment_container"
           android:layout_width="match_parent"
           android:layout_height="match_parent"
-          >
-
-          <com.modulecheck.lib1.Lib1View
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
+          />
         """,
         SourceSetName.DEBUG
       )
@@ -433,14 +388,7 @@ class DisableViewBindingTest : RunnerTest() {
           android:id="@+id/fragment_container"
           android:layout_width="match_parent"
           android:layout_height="match_parent"
-          >
-
-          <com.modulecheck.lib1.Lib1View
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
+          />
         """
       )
     }
@@ -490,14 +438,7 @@ class DisableViewBindingTest : RunnerTest() {
           android:id="@+id/fragment_container"
           android:layout_width="match_parent"
           android:layout_height="match_parent"
-          >
-
-          <com.modulecheck.lib1.Lib1View
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
+          />
         """
       )
     }
@@ -710,14 +651,7 @@ class DisableViewBindingTest : RunnerTest() {
           android:id="@+id/fragment_container"
           android:layout_width="match_parent"
           android:layout_height="match_parent"
-          >
-
-          <com.modulecheck.lib1.Lib1View
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
+          />
         """
       )
     }
@@ -769,14 +703,7 @@ class DisableViewBindingTest : RunnerTest() {
           android:id="@+id/fragment_container"
           android:layout_width="match_parent"
           android:layout_height="match_parent"
-          >
-
-          <com.modulecheck.lib1.Lib1View
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
+          />
         """
       )
     }
@@ -830,14 +757,7 @@ class DisableViewBindingTest : RunnerTest() {
           android:id="@+id/fragment_container"
           android:layout_width="match_parent"
           android:layout_height="match_parent"
-          >
-
-          <com.modulecheck.lib1.Lib1View
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
+          />
         """
       )
     }

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/GraphVizReportTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/GraphVizReportTest.kt
@@ -29,7 +29,7 @@ import java.io.File
 
 internal class GraphVizReportTest : RunnerTest() {
 
-  val findingFactory by resets { SingleRuleFindingFactory(DepthRule()) }
+  override val findingFactory by resets { SingleRuleFindingFactory(DepthRule()) }
 
   fun McProject.graphFile(sourceSet: String = "main"): File {
     return projectDir.child(

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/GraphVizReportTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/GraphVizReportTest.kt
@@ -46,11 +46,6 @@ internal class GraphVizReportTest : RunnerTest() {
 
     settings.reports.graphs.enabled = false
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1")
 
     val lib2 = project(":lib2") {
@@ -62,9 +57,7 @@ internal class GraphVizReportTest : RunnerTest() {
       addDependency(ConfigurationName.implementation, lib2)
     }
 
-    val result = runner.run(allProjects())
-
-    result.isSuccess shouldBe true
+    run(autoCorrect = false).isSuccess shouldBe true
 
     lib2.graphFile().exists() shouldBe false
   }
@@ -73,11 +66,6 @@ internal class GraphVizReportTest : RunnerTest() {
   fun `depth report should be created if enabled in settings`() {
 
     settings.reports.graphs.enabled = true
-
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1")
 
@@ -90,9 +78,7 @@ internal class GraphVizReportTest : RunnerTest() {
       addDependency(ConfigurationName.implementation, lib2)
     }
 
-    val result = runner.run(allProjects())
-
-    result.isSuccess shouldBe true
+    run(autoCorrect = false).isSuccess shouldBe true
 
     app.graphFile().readText() shouldBe """
       strict digraph DependencyGraph {
@@ -120,11 +106,6 @@ internal class GraphVizReportTest : RunnerTest() {
 
     settings.reports.graphs.enabled = true
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1") {
 
       val myFile = File(projectDir, "src/main/kotlin/MyFile.kt").createSafely()
@@ -135,9 +116,7 @@ internal class GraphVizReportTest : RunnerTest() {
       )
     }
 
-    val result = runner.run(allProjects())
-
-    result.isSuccess shouldBe true
+    run(autoCorrect = false).isSuccess shouldBe true
 
     lib1.graphFile().readText() shouldBe """
       strict digraph DependencyGraph {
@@ -156,18 +135,11 @@ internal class GraphVizReportTest : RunnerTest() {
 
     settings.reports.graphs.enabled = true
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1") {
       sourceSets[SourceSetName.MAIN] = SourceSet(name = SourceSetName.MAIN)
     }
 
-    val result = runner.run(allProjects())
-
-    result.isSuccess shouldBe true
+    run(autoCorrect = false).isSuccess shouldBe true
 
     lib1.graphFile().exists() shouldBe false
   }
@@ -176,11 +148,6 @@ internal class GraphVizReportTest : RunnerTest() {
   fun `test source set graph should be test-specific`() {
 
     settings.reports.graphs.enabled = true
-
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSourceSet(SourceSetName.TEST)
@@ -203,9 +170,7 @@ internal class GraphVizReportTest : RunnerTest() {
 
     lib1.addDependency(ConfigurationName("testImplementation"), lib2)
 
-    val result = runner.run(allProjects())
-
-    result.isSuccess shouldBe true
+    run(autoCorrect = false).isSuccess shouldBe true
 
     app.graphFile().readText() shouldBe """
       strict digraph DependencyGraph {
@@ -274,11 +239,6 @@ internal class GraphVizReportTest : RunnerTest() {
 
     settings.reports.graphs.enabled = true
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1")
     val debug1 = project(":debug1") {
       addDependency(ConfigurationName.implementation, lib1)
@@ -299,9 +259,7 @@ internal class GraphVizReportTest : RunnerTest() {
       addDependency(ConfigurationName("debugImplementation"), debug2)
     }
 
-    val result = runner.run(allProjects())
-
-    result.isSuccess shouldBe true
+    run(autoCorrect = false).isSuccess shouldBe true
 
     app.graphFile().readText() shouldBe """
       strict digraph DependencyGraph {

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/InheritedDependenciesTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/InheritedDependenciesTest.kt
@@ -1477,16 +1477,6 @@ class InheritedDependenciesTest : RunnerTest() {
 
     run().isSuccess shouldBe true
 
-    lib2.buildFile.readText() shouldBe """
-        plugins {
-          kotlin("jvm")
-        }
-
-        dependencies {
-          api(testFixtures(project(path = ":lib1")))
-        }
-    """
-
     lib3.buildFile.readText() shouldBe """
         plugins {
           kotlin("jvm")

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/InheritedDependenciesTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/InheritedDependenciesTest.kt
@@ -266,9 +266,7 @@ class InheritedDependenciesTest : RunnerTest() {
     }
     lib1.addDependency(ConfigurationName.api, lib2)
 
-    run(
-      autoCorrect = false
-    ).isSuccess shouldBe true
+    run(autoCorrect = false).isSuccess shouldBe true
 
     logger.parsedReport() shouldBe listOf()
 

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/MustBeApiTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/MustBeApiTest.kt
@@ -15,8 +15,6 @@
 
 package modulecheck.core
 
-import modulecheck.core.rule.ModuleCheckRuleFactory
-import modulecheck.core.rule.MultiRuleFindingFactory
 import modulecheck.parsing.gradle.ConfigurationName
 import modulecheck.parsing.gradle.SourceSetName
 import modulecheck.runtime.test.ProjectFindingReport.mustBeApi
@@ -24,15 +22,6 @@ import modulecheck.runtime.test.RunnerTest
 import org.junit.jupiter.api.Test
 
 class MustBeApiTest : RunnerTest() {
-
-  val ruleFactory by resets { ModuleCheckRuleFactory() }
-
-  val findingFactory by resets {
-    MultiRuleFindingFactory(
-      settings,
-      ruleFactory.create(settings)
-    )
-  }
 
   @Test
   fun `public property from implementation without auto-correct should fail`() {

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/MustBeApiTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/MustBeApiTest.kt
@@ -26,11 +26,6 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `public property from implementation without auto-correct should fail`() {
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
@@ -69,7 +64,9 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe false
+    run(
+      autoCorrect = false
+    ).isSuccess shouldBe false
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -95,11 +92,6 @@ class MustBeApiTest : RunnerTest() {
 
   @Test
   fun `public generic property from implementation without auto-correct should fail`() {
-
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -139,7 +131,9 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe false
+    run(
+      autoCorrect = false
+    ).isSuccess shouldBe false
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -165,11 +159,6 @@ class MustBeApiTest : RunnerTest() {
 
   @Test
   fun `public property from implementation with auto-correct should be fixed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -209,7 +198,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -235,11 +224,6 @@ class MustBeApiTest : RunnerTest() {
 
   @Test
   fun `private property from implementation with auto-correct should not be changed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -279,7 +263,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -296,11 +280,6 @@ class MustBeApiTest : RunnerTest() {
 
   @Test
   fun `private property from implementation inside public class with auto-correct should not be changed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -342,7 +321,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -359,11 +338,6 @@ class MustBeApiTest : RunnerTest() {
 
   @Test
   fun `internal property from implementation with auto-correct should not be changed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -403,7 +377,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -420,11 +394,6 @@ class MustBeApiTest : RunnerTest() {
 
   @Test
   fun `public property from dependency in test source should not require API`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -465,7 +434,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -482,11 +451,6 @@ class MustBeApiTest : RunnerTest() {
 
   @Test
   fun `internal property in class from implementation with auto-correct should not be changed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -528,7 +492,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -545,11 +509,6 @@ class MustBeApiTest : RunnerTest() {
 
   @Test
   fun `supertype from implementation with auto-correct should be fixed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -589,7 +548,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -615,11 +574,6 @@ class MustBeApiTest : RunnerTest() {
 
   @Test
   fun `auto-correct should only replace the configuration invocation text`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":implementation") {
       addSource(
@@ -661,7 +615,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -689,11 +643,6 @@ class MustBeApiTest : RunnerTest() {
 
   @Test
   fun `supertype of internal class from implementation with auto-correct should not be changed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -733,7 +682,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -750,11 +699,6 @@ class MustBeApiTest : RunnerTest() {
 
   @Test
   fun `public return type from implementation with auto-correct should be fixed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -794,7 +738,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -820,11 +764,6 @@ class MustBeApiTest : RunnerTest() {
 
   @Test
   fun `internal return type from implementation with auto-correct should not be changed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -864,7 +803,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -881,11 +820,6 @@ class MustBeApiTest : RunnerTest() {
 
   @Test
   fun `public argument type from implementation with auto-correct should be fixed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -925,7 +859,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -951,11 +885,6 @@ class MustBeApiTest : RunnerTest() {
 
   @Test
   fun `public type argument from implementation with auto-correct should be fixed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -995,7 +924,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -1021,11 +950,6 @@ class MustBeApiTest : RunnerTest() {
 
   @Test
   fun `public generic bound type from implementation with auto-correct should be fixed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -1065,7 +989,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -1091,11 +1015,6 @@ class MustBeApiTest : RunnerTest() {
 
   @Test
   fun `public generic fully qualified bound type from implementation with auto-correct should be fixed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -1133,7 +1052,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -1159,11 +1078,6 @@ class MustBeApiTest : RunnerTest() {
 
   @Test
   fun `two public public properties from implementation with auto-correct should be fixed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -1218,7 +1132,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -1251,11 +1165,6 @@ class MustBeApiTest : RunnerTest() {
 
   @Test
   fun `two public supertypes from implementation with auto-correct should be fixed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -1309,7 +1218,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -1342,11 +1251,6 @@ class MustBeApiTest : RunnerTest() {
 
   @Test
   fun `two public return types from implementation with auto-correct should be fixed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -1401,7 +1305,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -1434,11 +1338,6 @@ class MustBeApiTest : RunnerTest() {
 
   @Test
   fun `two public argument types from implementation with auto-correct should be fixed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -1493,7 +1392,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -1526,11 +1425,6 @@ class MustBeApiTest : RunnerTest() {
 
   @Test
   fun `two public type arguments from implementation with auto-correct should be fixed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -1584,7 +1478,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -1617,11 +1511,6 @@ class MustBeApiTest : RunnerTest() {
 
   @Test
   fun `two public generic bound types from implementation with auto-correct should be fixed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -1675,7 +1564,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/OverShotDependenciesTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/OverShotDependenciesTest.kt
@@ -27,11 +27,6 @@ class OverShotDependenciesTest : RunnerTest() {
   @Test
   fun `overshot as api but used in test without auto-correct should fail`() {
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
@@ -70,7 +65,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe false
+    run(autoCorrect = false).isSuccess shouldBe false
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -102,11 +97,6 @@ class OverShotDependenciesTest : RunnerTest() {
 
   @Test
   fun `overshot as implementation but used in debug without auto-correct should fail`() {
-
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -146,7 +136,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe false
+    run(autoCorrect = false).isSuccess shouldBe false
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -178,11 +168,6 @@ class OverShotDependenciesTest : RunnerTest() {
 
   @Test
   fun `overshot as api but used in test with auto-correct should be fixed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -222,7 +207,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -255,11 +240,6 @@ class OverShotDependenciesTest : RunnerTest() {
 
   @Test
   fun `overshot in android project as implementation but used in debug with auto-correct should be fixed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -299,7 +279,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -332,11 +312,6 @@ class OverShotDependenciesTest : RunnerTest() {
 
   @Test
   fun `overshot in non-android as implementation but used in debug with auto-correct should be fixed with quotes`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -376,7 +351,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -409,11 +384,6 @@ class OverShotDependenciesTest : RunnerTest() {
 
   @Test
   fun `overshot as api but used in test with another testFixture with auto-correct should be fixed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -473,7 +443,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib3.buildFile.readText() shouldBe """
         plugins {
@@ -507,11 +477,6 @@ class OverShotDependenciesTest : RunnerTest() {
 
   @Test
   fun `overshot as api with config block and comment with auto-correct should be fixed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -573,7 +538,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib3.buildFile.readText() shouldBe """
         plugins {
@@ -613,11 +578,6 @@ class OverShotDependenciesTest : RunnerTest() {
 
   @Test
   fun `overshot testFixture as api but used in test with another testFixture with auto-correct should be fixed`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -678,7 +638,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib3.buildFile.readText() shouldBe """
         plugins {

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/OverShotDependenciesTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/OverShotDependenciesTest.kt
@@ -15,8 +15,6 @@
 
 package modulecheck.core
 
-import modulecheck.core.rule.ModuleCheckRuleFactory
-import modulecheck.core.rule.MultiRuleFindingFactory
 import modulecheck.parsing.gradle.ConfigurationName
 import modulecheck.parsing.gradle.SourceSetName
 import modulecheck.runtime.test.ProjectFindingReport.overshot
@@ -25,15 +23,6 @@ import modulecheck.runtime.test.RunnerTest
 import org.junit.jupiter.api.Test
 
 class OverShotDependenciesTest : RunnerTest() {
-
-  val ruleFactory by resets { ModuleCheckRuleFactory() }
-
-  val findingFactory by resets {
-    MultiRuleFindingFactory(
-      settings,
-      ruleFactory.create(settings)
-    )
-  }
 
   @Test
   fun `overshot as api but used in test without auto-correct should fail`() {

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/SortDependenciesTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/SortDependenciesTest.kt
@@ -33,11 +33,6 @@ class SortDependenciesTest : RunnerTest() {
   @Test
   fun `kts out-of-order dependencies should be sorted`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1") {
       buildFile.writeKotlin(
         """
@@ -64,7 +59,7 @@ class SortDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -103,11 +98,6 @@ class SortDependenciesTest : RunnerTest() {
   @Test
   fun `kts multi-line comments should move with their declarations`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1") {
       buildFile.writeKotlin(
         """
@@ -127,7 +117,7 @@ class SortDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -153,11 +143,6 @@ class SortDependenciesTest : RunnerTest() {
   @Test
   fun `kts multi-line kdoc comments should move with their declarations`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1") {
       buildFile.writeKotlin(
         """
@@ -177,7 +162,7 @@ class SortDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -203,11 +188,6 @@ class SortDependenciesTest : RunnerTest() {
   @Test
   fun `kts preceding comments should move with their declarations`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1") {
       buildFile.writeKotlin(
         """
@@ -225,7 +205,7 @@ class SortDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -249,11 +229,6 @@ class SortDependenciesTest : RunnerTest() {
   @Test
   fun `kts trailing comments should move with their declarations`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1") {
       buildFile.writeKotlin(
         """
@@ -270,7 +245,7 @@ class SortDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -292,11 +267,6 @@ class SortDependenciesTest : RunnerTest() {
 
   @Test
   fun `kts sorting should be idempotent`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       buildFile.writeKotlin(
@@ -324,7 +294,7 @@ class SortDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -361,7 +331,7 @@ class SortDependenciesTest : RunnerTest() {
 
     logger.clear()
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -398,11 +368,6 @@ class SortDependenciesTest : RunnerTest() {
   @Test
   fun `groovy out-of-order plugins should be sorted`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1") {
       buildFile.delete()
       buildFile = File(projectDir, "build.gradle")
@@ -433,7 +398,7 @@ class SortDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -472,11 +437,6 @@ class SortDependenciesTest : RunnerTest() {
   @Test
   fun `groovy multi-line comments should move with declarations`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1") {
       buildFile.delete()
       buildFile = File(projectDir, "build.gradle")
@@ -498,7 +458,7 @@ class SortDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -524,11 +484,6 @@ class SortDependenciesTest : RunnerTest() {
   @Test
   fun `groovy multi-line javadoc comments should move with declarations`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1") {
       buildFile.delete()
       buildFile = File(projectDir, "build.gradle")
@@ -550,7 +505,7 @@ class SortDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -576,11 +531,6 @@ class SortDependenciesTest : RunnerTest() {
   @Test
   fun `groovy preceding comments should move with declarations`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1") {
       buildFile.delete()
       buildFile = File(projectDir, "build.gradle")
@@ -600,7 +550,7 @@ class SortDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -624,11 +574,6 @@ class SortDependenciesTest : RunnerTest() {
   @Test
   fun `groovy trailing comments should move with declarations`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1") {
       buildFile.delete()
       buildFile = File(projectDir, "build.gradle")
@@ -647,7 +592,7 @@ class SortDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -669,11 +614,6 @@ class SortDependenciesTest : RunnerTest() {
 
   @Test
   fun `groovy sorting should be idempotent`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       buildFile.delete()
@@ -706,7 +646,7 @@ class SortDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -742,7 +682,7 @@ class SortDependenciesTest : RunnerTest() {
     )
     logger.clear()
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/SortDependenciesTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/SortDependenciesTest.kt
@@ -17,8 +17,6 @@ package modulecheck.core
 
 import modulecheck.api.test.TestChecksSettings
 import modulecheck.api.test.TestSettings
-import modulecheck.core.rule.ModuleCheckRuleFactory
-import modulecheck.core.rule.MultiRuleFindingFactory
 import modulecheck.runtime.test.ProjectFindingReport.unsortedDependencies
 import modulecheck.runtime.test.RunnerTest
 import modulecheck.testing.writeGroovy
@@ -28,16 +26,8 @@ import java.io.File
 
 class SortDependenciesTest : RunnerTest() {
 
-  val ruleFactory by resets { ModuleCheckRuleFactory() }
-
   override val settings by resets {
     TestSettings(checks = TestChecksSettings(sortDependencies = true))
-  }
-  val findingFactory by resets {
-    MultiRuleFindingFactory(
-      settings,
-      ruleFactory.create(settings)
-    )
   }
 
   @Test

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/SortPluginsTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/SortPluginsTest.kt
@@ -31,11 +31,6 @@ class SortPluginsTest : RunnerTest() {
   @Test
   fun `kts out-of-order plugins should be sorted`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1") {
       buildFile.writeKotlin(
         """
@@ -48,7 +43,7 @@ class SortPluginsTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -66,11 +61,6 @@ class SortPluginsTest : RunnerTest() {
   @Test
   fun `kts sorting should be idempotent`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1") {
       buildFile.writeKotlin(
         """
@@ -83,7 +73,7 @@ class SortPluginsTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -98,7 +88,7 @@ class SortPluginsTest : RunnerTest() {
     )
     logger.clear()
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -114,11 +104,6 @@ class SortPluginsTest : RunnerTest() {
   @Test
   fun `groovy out-of-order plugins should be sorted`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1") {
       buildFile.delete()
       buildFile = File(projectDir, "build.gradle")
@@ -133,7 +118,7 @@ class SortPluginsTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -151,11 +136,6 @@ class SortPluginsTest : RunnerTest() {
   @Test
   fun `groovy sorting should be idempotent`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1") {
       buildFile.delete()
       buildFile = File(projectDir, "build.gradle")
@@ -170,7 +150,7 @@ class SortPluginsTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {
@@ -185,7 +165,7 @@ class SortPluginsTest : RunnerTest() {
     )
     logger.clear()
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib1.buildFile.readText() shouldBe """
       plugins {

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/SortPluginsTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/SortPluginsTest.kt
@@ -17,8 +17,6 @@ package modulecheck.core
 
 import modulecheck.api.test.TestChecksSettings
 import modulecheck.api.test.TestSettings
-import modulecheck.core.rule.ModuleCheckRuleFactory
-import modulecheck.core.rule.MultiRuleFindingFactory
 import modulecheck.runtime.test.ProjectFindingReport.unsortedPlugins
 import modulecheck.runtime.test.RunnerTest
 import modulecheck.testing.writeGroovy
@@ -28,15 +26,7 @@ import java.io.File
 
 class SortPluginsTest : RunnerTest() {
 
-  val ruleFactory by resets { ModuleCheckRuleFactory() }
-
   override val settings by resets { TestSettings(checks = TestChecksSettings(sortPlugins = true)) }
-  val findingFactory by resets {
-    MultiRuleFindingFactory(
-      settings,
-      ruleFactory.create(settings)
-    )
-  }
 
   @Test
   fun `kts out-of-order plugins should be sorted`() {

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/TextReportingTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/TextReportingTest.kt
@@ -38,7 +38,7 @@ internal class TextReportingTest : RunnerTest() {
 
     val outputFile = File(settings.reports.text.outputPath)
 
-    val runner = runner(
+    run(
       autoCorrect = false,
       findingFactory = findingFactory(
         listOf(
@@ -63,11 +63,7 @@ internal class TextReportingTest : RunnerTest() {
           )
         )
       }
-    )
-
-    val result = runner.run(listOf())
-
-    result.isSuccess shouldBe true
+    ).isSuccess shouldBe true
 
     outputFile.exists() shouldBe false
   }
@@ -79,7 +75,7 @@ internal class TextReportingTest : RunnerTest() {
 
     val outputFile = File(settings.reports.text.outputPath)
 
-    val runner = runner(
+    run(
       autoCorrect = false,
       findingFactory = findingFactory(
         listOf(
@@ -104,11 +100,7 @@ internal class TextReportingTest : RunnerTest() {
           )
         }
       }
-    )
-
-    val result = runner.run(listOf())
-
-    result.isSuccess shouldBe true
+    ).isSuccess shouldBe true
 
     outputFile.readText()
       .clean()

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/UnusedDependenciesTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/UnusedDependenciesTest.kt
@@ -28,11 +28,6 @@ class UnusedDependenciesTest : RunnerTest() {
   @Test
   fun `unused without auto-correct should fail`() {
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1")
 
     val lib2 = project(":lib2") {
@@ -51,7 +46,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe false
+    run(autoCorrect = false).isSuccess shouldBe false
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -78,11 +73,6 @@ class UnusedDependenciesTest : RunnerTest() {
   @Test
   fun `unused with auto-correct should be commented out`() {
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1")
 
     val lib2 = project(":lib2") {
@@ -101,7 +91,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -130,11 +120,6 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = true
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1")
 
     val lib2 = project(":lib2") {
@@ -153,7 +138,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -181,11 +166,6 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = true
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1")
 
     val lib2 = project(":lib2") {
@@ -205,7 +185,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -226,11 +206,6 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = true
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1")
 
     val lib2 = project(":lib2") {
@@ -250,7 +225,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -271,11 +246,6 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = true
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1")
 
     val lib2 = project(":lib2") {
@@ -295,7 +265,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -324,11 +294,6 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = true
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1")
 
     val lib2 = project(":lib2") {
@@ -347,7 +312,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -375,11 +340,6 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = true
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1")
 
     val lib2 = project(":lib2") {
@@ -398,7 +358,9 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe false
+    run(
+      autoCorrect = false
+    ).isSuccess shouldBe false
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -427,11 +389,6 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = true
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1")
 
     val lib2 = project(":lib2") {
@@ -452,7 +409,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -482,11 +439,6 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = false
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1")
 
     val lib2 = project(":lib2") {
@@ -507,7 +459,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -538,11 +490,6 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = false
 
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
-
     val lib1 = project(":lib1")
 
     val lib2 = project(":lib2") {
@@ -564,7 +511,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -595,11 +542,6 @@ class UnusedDependenciesTest : RunnerTest() {
   fun `testImplementation used in test should not be unused`() {
 
     settings.deleteUnused = false
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -640,7 +582,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -659,11 +601,6 @@ class UnusedDependenciesTest : RunnerTest() {
   fun `androidTestImplementation used in androidTest should not be unused`() {
 
     settings.deleteUnused = false
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       addSource(
@@ -705,7 +642,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -725,11 +662,6 @@ class UnusedDependenciesTest : RunnerTest() {
   fun `custom view used in a layout file should not be unused`() {
 
     settings.deleteUnused = false
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       addSource(
@@ -778,7 +710,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -798,11 +730,6 @@ class UnusedDependenciesTest : RunnerTest() {
   fun `module contributing a used generated DataBinding object should not be unused`() {
 
     settings.deleteUnused = false
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
       viewBindingEnabled = true
@@ -844,7 +771,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -864,11 +791,6 @@ class UnusedDependenciesTest : RunnerTest() {
   fun `declaration used via a wildcard import should not be unused`() {
 
     settings.deleteUnused = false
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -908,7 +830,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -927,11 +849,6 @@ class UnusedDependenciesTest : RunnerTest() {
   fun `testFixtures declaration used in test should not be unused`() {
 
     settings.deleteUnused = false
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -973,7 +890,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -992,11 +909,6 @@ class UnusedDependenciesTest : RunnerTest() {
   fun `unused from testFixtures with auto-correct should be fixed`() {
 
     settings.deleteUnused = false
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -1026,7 +938,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -1054,11 +966,6 @@ class UnusedDependenciesTest : RunnerTest() {
   fun `static member declaration used via wildcard import should not be unused`() {
 
     settings.deleteUnused = false
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -1102,7 +1009,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -1121,11 +1028,6 @@ class UnusedDependenciesTest : RunnerTest() {
   fun `string resource used in module should not be unused`() {
 
     settings.deleteUnused = false
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
 
@@ -1165,7 +1067,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -1185,11 +1087,6 @@ class UnusedDependenciesTest : RunnerTest() {
   fun `string resource used in manifest should not be unused`() {
 
     settings.deleteUnused = false
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
 
@@ -1240,7 +1137,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {
@@ -1260,11 +1157,6 @@ class UnusedDependenciesTest : RunnerTest() {
   fun `declaration used via class reference wtih wildcard import should not be unused`() {
 
     settings.deleteUnused = false
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val lib1 = project(":lib1") {
       addSource(
@@ -1310,7 +1202,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     lib2.buildFile.readText() shouldBe """
         plugins {

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/UnusedDependenciesTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/UnusedDependenciesTest.kt
@@ -15,8 +15,6 @@
 
 package modulecheck.core
 
-import modulecheck.core.rule.ModuleCheckRuleFactory
-import modulecheck.core.rule.MultiRuleFindingFactory
 import modulecheck.parsing.gradle.ConfigurationName
 import modulecheck.parsing.gradle.SourceSetName
 import modulecheck.parsing.source.AnvilGradlePlugin
@@ -26,15 +24,6 @@ import net.swiftzer.semver.SemVer
 import org.junit.jupiter.api.Test
 
 class UnusedDependenciesTest : RunnerTest() {
-
-  val ruleFactory by resets { ModuleCheckRuleFactory() }
-
-  val findingFactory by resets {
-    MultiRuleFindingFactory(
-      settings,
-      ruleFactory.create(settings)
-    )
-  }
 
   @Test
   fun `unused without auto-correct should fail`() {

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/UnusedKaptProcessorTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/UnusedKaptProcessorTest.kt
@@ -15,8 +15,6 @@
 
 package modulecheck.core
 
-import modulecheck.core.rule.ModuleCheckRuleFactory
-import modulecheck.core.rule.MultiRuleFindingFactory
 import modulecheck.parsing.gradle.ConfigurationName
 import modulecheck.parsing.gradle.SourceSetName
 import modulecheck.parsing.gradle.asConfigurationName
@@ -26,15 +24,6 @@ import modulecheck.runtime.test.RunnerTest
 import org.junit.jupiter.api.Test
 
 class UnusedKaptProcessorTest : RunnerTest() {
-
-  val ruleFactory by resets { ModuleCheckRuleFactory() }
-
-  val findingFactory by resets {
-    MultiRuleFindingFactory(
-      settings,
-      ruleFactory.create(settings)
-    )
-  }
 
   val dagger = "com.google.dagger:dagger-compiler:2.40.5"
 

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/UnusedKaptProcessorTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/UnusedKaptProcessorTest.kt
@@ -30,11 +30,6 @@ class UnusedKaptProcessorTest : RunnerTest() {
   @Test
   fun `unused from kapt configuration without autoCorrect should fail`() {
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val app = project(":app") {
       hasKapt = true
 
@@ -54,7 +49,9 @@ class UnusedKaptProcessorTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe false
+    run(
+      autoCorrect = false
+    ).isSuccess shouldBe false
 
     app.buildFile.readText() shouldBe """
         plugins {
@@ -87,11 +84,6 @@ class UnusedKaptProcessorTest : RunnerTest() {
   @Test
   fun `unused from non-kapt configuration without autoCorrect should pass without changes`() {
 
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
-
     val app = project(":app") {
       hasKapt = true
 
@@ -111,7 +103,9 @@ class UnusedKaptProcessorTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run(
+      autoCorrect = false
+    ).isSuccess shouldBe true
 
     app.buildFile.readText() shouldBe """
         plugins {
@@ -129,11 +123,6 @@ class UnusedKaptProcessorTest : RunnerTest() {
 
   @Test
   fun `used in main with main kapt should pass without changes`() {
-
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
 
     val app = project(":app") {
       hasKapt = true
@@ -164,7 +153,9 @@ class UnusedKaptProcessorTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run(
+      autoCorrect = false
+    ).isSuccess shouldBe true
 
     app.buildFile.readText() shouldBe """
         plugins {
@@ -182,11 +173,6 @@ class UnusedKaptProcessorTest : RunnerTest() {
 
   @Test
   fun `used in test with test kapt should pass without changes`() {
-
-    val runner = runner(
-      autoCorrect = false,
-      findingFactory = findingFactory
-    )
 
     val app = project(":app") {
       hasKapt = true
@@ -218,7 +204,9 @@ class UnusedKaptProcessorTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run(
+      autoCorrect = false
+    ).isSuccess shouldBe true
 
     app.buildFile.readText() shouldBe """
         plugins {
@@ -236,11 +224,6 @@ class UnusedKaptProcessorTest : RunnerTest() {
 
   @Test
   fun `unused with main kapt with autoCorrect and no other processors should remove processor and plugin`() {
-
-    val runner = runner(
-      autoCorrect = true,
-      findingFactory = findingFactory
-    )
 
     val app = project(":app") {
       hasKapt = true
@@ -261,7 +244,7 @@ class UnusedKaptProcessorTest : RunnerTest() {
       )
     }
 
-    runner.run(allProjects()).isSuccess shouldBe true
+    run().isSuccess shouldBe true
 
     app.buildFile.readText() shouldBe """
       plugins {

--- a/modulecheck-runtime/build.gradle.kts
+++ b/modulecheck-runtime/build.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
 
   testFixturesApi(libs.bundles.hermit)
 
+  testFixturesApi(project(path = ":modulecheck-core"))
+
   testFixturesApi(testFixtures(project(path = ":modulecheck-api")))
   testFixturesApi(testFixtures(project(path = ":modulecheck-project:api")))
 

--- a/modulecheck-runtime/src/testFixtures/kotlin/modulecheck/runtime/test/RunnerTest.kt
+++ b/modulecheck-runtime/src/testFixtures/kotlin/modulecheck/runtime/test/RunnerTest.kt
@@ -52,34 +52,9 @@ abstract class RunnerTest : ProjectTest() {
   }
 
   @Suppress("LongParameterList")
-  fun runner(
-    autoCorrect: Boolean = true,
-    findingFactory: FindingFactory<out Finding> = this.findingFactory,
-    settings: ModuleCheckSettings = this.settings,
-    logger: Logger = this.logger,
-    projectProvider: ProjectProvider = this.projectProvider,
-    findingResultFactory: FindingResultFactory = RealFindingResultFactory(),
-    reportFactory: ReportFactory = ReportFactory(),
-    checkstyleReporter: CheckstyleReporter = CheckstyleReporter(),
-    graphvizFileWriter: GraphvizFileWriter = GraphvizFileWriter(settings, GraphvizFactory()),
-    dispatcherProvider: DispatcherProvider = DispatcherProvider()
-  ): ModuleCheckRunner = ModuleCheckRunner(
-    autoCorrect = autoCorrect,
-    settings = settings,
-    findingFactory = findingFactory,
-    logger = logger,
-    findingResultFactory = findingResultFactory,
-    reportFactory = reportFactory,
-    checkstyleReporter = checkstyleReporter,
-    graphvizFileWriter = graphvizFileWriter,
-    dispatcherProvider = dispatcherProvider,
-    projectProvider = projectProvider
-  )
-
-  @Suppress("LongParameterList")
   fun run(
     autoCorrect: Boolean = true,
-    strictResolution: Boolean = true,
+    strictResolution: Boolean = false,
     findingFactory: FindingFactory<out Finding> = this.findingFactory,
     settings: ModuleCheckSettings = this.settings,
     logger: Logger = this.logger,

--- a/modulecheck-runtime/src/testFixtures/kotlin/modulecheck/runtime/test/RunnerTest.kt
+++ b/modulecheck-runtime/src/testFixtures/kotlin/modulecheck/runtime/test/RunnerTest.kt
@@ -16,13 +16,18 @@
 package modulecheck.runtime.test
 
 import dispatch.core.DispatcherProvider
+import io.kotest.assertions.asClue
+import io.kotest.common.runBlocking
 import modulecheck.api.finding.Finding
 import modulecheck.api.finding.FindingFactory
 import modulecheck.api.finding.FindingResultFactory
 import modulecheck.api.finding.RealFindingResultFactory
+import modulecheck.api.rule.RuleFactory
 import modulecheck.api.settings.ModuleCheckSettings
 import modulecheck.api.test.ReportingLogger
 import modulecheck.api.test.TestSettings
+import modulecheck.core.rule.ModuleCheckRuleFactory
+import modulecheck.core.rule.MultiRuleFindingFactory
 import modulecheck.project.Logger
 import modulecheck.project.McProject
 import modulecheck.project.ProjectProvider
@@ -35,13 +40,21 @@ import modulecheck.runtime.ModuleCheckRunner
 
 abstract class RunnerTest : ProjectTest() {
 
-  open val settings by resets { TestSettings() }
-  open val logger by resets { ReportingLogger() }
+  open val settings: ModuleCheckSettings by resets { TestSettings() }
+  open val logger: ReportingLogger by resets { ReportingLogger() }
+
+  open val ruleFactory: RuleFactory by resets { ModuleCheckRuleFactory() }
+  open val findingFactory: FindingFactory<Finding> by resets {
+    MultiRuleFindingFactory(
+      settings,
+      ruleFactory.create(settings)
+    )
+  }
 
   @Suppress("LongParameterList")
   fun runner(
-    autoCorrect: Boolean,
-    findingFactory: FindingFactory<out Finding>,
+    autoCorrect: Boolean = true,
+    findingFactory: FindingFactory<out Finding> = this.findingFactory,
     settings: ModuleCheckSettings = this.settings,
     logger: Logger = this.logger,
     projectProvider: ProjectProvider = this.projectProvider,
@@ -62,6 +75,55 @@ abstract class RunnerTest : ProjectTest() {
     dispatcherProvider = dispatcherProvider,
     projectProvider = projectProvider
   )
+
+  @Suppress("LongParameterList")
+  fun run(
+    autoCorrect: Boolean = true,
+    strictResolution: Boolean = true,
+    findingFactory: FindingFactory<out Finding> = this.findingFactory,
+    settings: ModuleCheckSettings = this.settings,
+    logger: Logger = this.logger,
+    projectProvider: ProjectProvider = this.projectProvider,
+    findingResultFactory: FindingResultFactory = RealFindingResultFactory(),
+    reportFactory: ReportFactory = ReportFactory(),
+    checkstyleReporter: CheckstyleReporter = CheckstyleReporter(),
+    graphvizFileWriter: GraphvizFileWriter = GraphvizFileWriter(settings, GraphvizFactory()),
+    dispatcherProvider: DispatcherProvider = DispatcherProvider()
+  ): Result<Unit> = runBlocking {
+
+    "Resolving all references BEFORE running ModuleCheck".asClue {
+      if (strictResolution) {
+        resolveReferences()
+      }
+    }
+
+    val result = ModuleCheckRunner(
+      autoCorrect = autoCorrect,
+      settings = settings,
+      findingFactory = findingFactory,
+      logger = logger,
+      findingResultFactory = findingResultFactory,
+      reportFactory = reportFactory,
+      checkstyleReporter = checkstyleReporter,
+      graphvizFileWriter = graphvizFileWriter,
+      dispatcherProvider = dispatcherProvider,
+      projectProvider = projectProvider
+    ).run(allProjects())
+
+    if (autoCorrect) {
+
+      // Re-parse everything from scratch to ensure that auto-correct didn't break anything.
+      projectCache.clearContexts()
+
+      "Resolving all references after auto-correct\n".asClue {
+        if (strictResolution) {
+          resolveReferences()
+        }
+      }
+    }
+
+    return@runBlocking result
+  }
 
   fun findingFactory(
     fixable: List<Finding> = emptyList(),


### PR DESCRIPTION
For each test project in a test, parse all references and dependencies and assert that everything

This adds functionality to parse all references and dependencies in each test project of a test, then assert that everything can be resolved.

This is done automatically before and after execution of the runner, to ensure that (1) the test is checking valid state, and (2) auto-corrections don't break anything.

Currently, some tests aren't actually valid and some auto-correction is actually breaking stuff.  So, for the moment the check is disabled.  Some follow-up PRs will fix those tests, and then the check will be enabled.