### PR TITLE
better handling for detecting complex precompiled configuration names

### DIFF
--- a/modulecheck-parsing/gradle/src/main/kotlin/modulecheck/parsing/gradle/SourceSet.kt
+++ b/modulecheck-parsing/gradle/src/main/kotlin/modulecheck/parsing/gradle/SourceSet.kt
@@ -16,6 +16,7 @@
 package modulecheck.parsing.gradle
 
 import modulecheck.utils.capitalize
+import modulecheck.utils.decapitalize
 import modulecheck.utils.mapToSet
 import java.io.File
 
@@ -130,3 +131,27 @@ fun String.asSourceSetName(): SourceSetName = SourceSetName(this)
 class SourceSets(
   delegate: Map<SourceSetName, SourceSet>
 ) : Map<SourceSetName, SourceSet> by delegate
+
+fun SourceSetName.removePrefix(prefix: String) = value.removePrefix(prefix)
+  .decapitalize()
+  .asSourceSetName()
+
+fun SourceSetName.removePrefix(prefix: SourceSetName) = removePrefix(prefix.value)
+
+fun SourceSetName.hasPrefix(prefix: String) = value.startsWith(prefix)
+fun SourceSetName.hasPrefix(prefix: SourceSetName) = hasPrefix(prefix.value)
+
+fun SourceSetName.addPrefix(prefix: String) = prefix.plus(value.capitalize())
+  .asSourceSetName()
+
+fun SourceSetName.addPrefix(prefix: SourceSetName) = addPrefix(prefix.value)
+
+fun SourceSetName.removeSuffix(suffix: String) = value.removeSuffix(suffix.capitalize())
+  .asSourceSetName()
+
+fun SourceSetName.removeSuffix(suffix: SourceSetName) = removeSuffix(suffix.value.capitalize())
+
+fun SourceSetName.addSuffix(suffix: String) = value.plus(suffix.capitalize())
+  .asSourceSetName()
+
+fun SourceSetName.addSuffix(suffix: SourceSetName) = addSuffix(suffix.value)


### PR DESCRIPTION
Given this dependencies block in a `.kts` build file for an Android module:

```kotlin
dependencies {
  api(project(path = ":lib2"))
}
```

If we want to add: `androidTestDebugImplementation(project(path = ":lib1"))`, it'll be added with quotes to be invoked as a string extension:

```kotlin
dependencies {
  "androidTestDebugImplementation"(project(path = ":lib1"))
  api(project(path = ":lib2"))
}
```

Instead, it should be this:
```kotlin
dependencies {
  androidTestDebugImplementation(project(path = ":lib1"))
  api(project(path = ":lib2"))
}
```

In short, the existing logic strips the configuration suffix (`-Implementation` in this case) from the name, in order to get the source set (`androidTestDebug`).  It then checks the source set name against the known default source sets added by this project's plugins (`androidTest`, `debug`, `main`, `release`, and `test` since this is Android), and if it matches one of those, then the configuration will be invoked without quotes.

In this case, the source set of `androidTestDebug` is still known at compile time, since it's just a combination of `androidTest` and `debug`.

This problem isn't unique to AGP.  Other combined configurations like `anvilTest` or `kaptAndroidTest` also have this problem.

The fix is recursion.  After stripping away the java configuration suffix, check the source set.  If it doesn't match a known one, try stripping away a known source set prefix and try the source set again.  This only ever removes precompiled names, so if there's ever a match, then the whole thing is precompiled and no quotes are needed.