### PR TITLE
don't swallow a newline when replacing a dependency with a preceding blank line

### DIFF
--- a/modulecheck-api/src/main/kotlin/modulecheck/api/finding/dependencies.kt
+++ b/modulecheck-api/src/main/kotlin/modulecheck/api/finding/dependencies.kt
@@ -31,6 +31,10 @@ fun McProject.addDependency(
   val oldStatement = markerDeclaration.statementWithSurroundingText
   val newStatement = newDeclaration.statementWithSurroundingText
 
+  // the `prefixIfNot("\n")` here is important.
+  // It needs to match what we're doing if we delete a dependency.  Otherwise, we wind up adding
+  // or removing newlines instead of just modifying the dependencies.
+  // See https://github.com/RBusarow/ModuleCheck/issues/443
   val combinedStatement = newStatement.plus(oldStatement.prefixIfNot("\n"))
 
   val buildFileText = buildFile.readText()
@@ -86,7 +90,11 @@ fun McProject.removeDependencyWithDelete(
   val text = buildFile.readText()
 
   buildFile.writeText(
-    text.replaceFirst(declaration.statementWithSurroundingText + '\n', "")
+    // the `prefixIfNot("\n")` here is important.
+    // It needs to match what we're doing if we add a new dependency.  Otherwise, we wind up adding
+    // or removing newlines instead of just modifying the dependencies.
+    // See https://github.com/RBusarow/ModuleCheck/issues/443
+    text.replaceFirst(declaration.statementWithSurroundingText.prefixIfNot("\n"), "")
   )
 
   if (configuredDependency is ConfiguredProjectDependency) {

--- a/modulecheck-parsing/psi/src/test/kotlin/modulecheck/parsing/psi/KotlinDependencyBlockParserTest.kt
+++ b/modulecheck-parsing/psi/src/test/kotlin/modulecheck/parsing/psi/KotlinDependencyBlockParserTest.kt
@@ -189,6 +189,47 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
   }
 
   @Test
+  fun `blank line between dependencies`() {
+    val block = KotlinDependencyBlockParser()
+      .parse(
+        """
+       dependencies {
+          api(testFixtures(project(":lib1")))
+
+          api(testFixtures(project(":lib2")))
+          implementation(testFixtures(project(":lib3")))
+       }
+        """
+      ).single()
+
+    block.settings shouldBe listOf(
+      ModuleDependencyDeclaration(
+        moduleRef = StringRef(":lib1"),
+        moduleAccess = """project(":lib1")""",
+        configName = ConfigurationName.api,
+        declarationText = """api(testFixtures(project(":lib1")))""",
+        statementWithSurroundingText = """   api(testFixtures(project(":lib1")))"""
+      ),
+      ModuleDependencyDeclaration(
+        moduleRef = StringRef(":lib2"),
+        moduleAccess = """project(":lib2")""",
+        configName = ConfigurationName.api,
+        declarationText = """api(testFixtures(project(":lib2")))""",
+        statementWithSurroundingText = """|
+           |   api(testFixtures(project(":lib2")))
+        """.trimMargin()
+      ),
+      ModuleDependencyDeclaration(
+        moduleRef = StringRef(":lib3"),
+        moduleAccess = """project(":lib3")""",
+        configName = ConfigurationName.implementation,
+        declarationText = """implementation(testFixtures(project(":lib3")))""",
+        statementWithSurroundingText = """   implementation(testFixtures(project(":lib3")))"""
+      ),
+    )
+  }
+
+  @Test
   fun `string module dependency declaration with testFixtures should be parsed`() {
     val block = KotlinDependencyBlockParser()
       .parse(


### PR DESCRIPTION
fixes #443