### PR TITLE
differentiate between Kotlin and Java names when parsing Kotlin files

### DIFF
--- a/modulecheck-api/src/main/kotlin/modulecheck/api/context/AndroidResourceReferences.kt
+++ b/modulecheck-api/src/main/kotlin/modulecheck/api/context/AndroidResourceReferences.kt
@@ -19,12 +19,13 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import modulecheck.parsing.gradle.SourceSetName
 import modulecheck.parsing.source.Reference
-import modulecheck.parsing.source.Reference.ExplicitReference
-import modulecheck.parsing.source.Reference.UnqualifiedRReference
+import modulecheck.parsing.source.Reference.ExplicitJavaReference
+import modulecheck.parsing.source.Reference.UnqualifiedJavaAndroidResourceReference
 import modulecheck.project.AndroidMcProject
 import modulecheck.project.McProject
 import modulecheck.project.ProjectContext
 import modulecheck.utils.LazySet
+import modulecheck.utils.LazySet.DataSource
 import modulecheck.utils.LazySet.DataSource.Priority.LOW
 import modulecheck.utils.SafeCache
 import modulecheck.utils.asDataSource
@@ -54,10 +55,10 @@ data class AndroidResourceReferences(
       ?.let { "$it." }
       ?: return emptyLazySet()
 
-    val jvm = project.jvmFilesForSourceSetName(sourceSetName)
+    val jvm: List<DataSource<Reference>> = project.jvmFilesForSourceSetName(sourceSetName)
       .map { jvmFile ->
 
-        lazy {
+        lazy<Set<Reference>> {
           jvmFile.interpretedReferencesLazy
             .value
             .asSequence()
@@ -66,8 +67,8 @@ data class AndroidResourceReferences(
             .flatMap { rReference ->
 
               listOf(
-                UnqualifiedRReference(rReference.removePrefix(packagePrefix)),
-                ExplicitReference(rReference)
+                UnqualifiedJavaAndroidResourceReference(rReference.removePrefix(packagePrefix)),
+                ExplicitJavaReference(rReference)
               )
             }
             .toSet()

--- a/modulecheck-core/src/main/kotlin/modulecheck/core/anvil/AnvilFactoryParser.kt
+++ b/modulecheck-core/src/main/kotlin/modulecheck/core/anvil/AnvilFactoryParser.kt
@@ -21,8 +21,7 @@ import modulecheck.api.context.references
 import modulecheck.parsing.gradle.SourceSetName
 import modulecheck.parsing.source.JavaFile
 import modulecheck.parsing.source.KotlinFile
-import modulecheck.parsing.source.asExplicitReference
-import modulecheck.parsing.source.contains
+import modulecheck.parsing.source.asExplicitKotlinReference
 import modulecheck.project.McProject
 import modulecheck.utils.any
 import net.swiftzer.semver.SemVer
@@ -30,11 +29,11 @@ import net.swiftzer.semver.SemVer
 object AnvilFactoryParser {
 
   private val anvilMergeComponent =
-    "com.squareup.anvil.annotations.MergeComponent".asExplicitReference()
-  private val daggerComponent = "dagger.Component".asExplicitReference()
+    "com.squareup.anvil.annotations.MergeComponent".asExplicitKotlinReference()
+  private val daggerComponent = "dagger.Component".asExplicitKotlinReference()
 
-  private const val daggerInject = "dagger.Inject"
-  private const val daggerModule = "dagger.Module"
+  private val daggerInject = "dagger.Inject".asExplicitKotlinReference()
+  private val daggerModule = "dagger.Module".asExplicitKotlinReference()
 
   @Suppress("MagicNumber")
   private val minimumAnvilVersion = SemVer(2, 0, 11)

--- a/modulecheck-core/src/main/kotlin/modulecheck/core/internal/uses.kt
+++ b/modulecheck-core/src/main/kotlin/modulecheck/core/internal/uses.kt
@@ -20,7 +20,6 @@ import modulecheck.api.context.anvilScopeContributionsForSourceSetName
 import modulecheck.api.context.declarations
 import modulecheck.api.context.referencesForSourceSetName
 import modulecheck.parsing.gradle.SourceSetName
-import modulecheck.parsing.source.contains
 import modulecheck.project.ConfiguredProjectDependency
 import modulecheck.project.McProject
 import modulecheck.utils.any

--- a/modulecheck-core/src/main/kotlin/modulecheck/core/rule/DisableViewBindingRule.kt
+++ b/modulecheck-core/src/main/kotlin/modulecheck/core/rule/DisableViewBindingRule.kt
@@ -23,7 +23,7 @@ import modulecheck.api.context.layoutFilesForSourceSetName
 import modulecheck.api.rule.ModuleCheckRule
 import modulecheck.api.settings.ChecksSettings
 import modulecheck.core.rule.android.DisableViewBindingGenerationFinding
-import modulecheck.parsing.source.asExplicitReference
+import modulecheck.parsing.source.asExplicitJavaReference
 import modulecheck.project.AndroidMcProject
 import modulecheck.project.McProject
 import modulecheck.utils.capitalize
@@ -60,7 +60,7 @@ class DisableViewBindingRule : ModuleCheckRule<DisableViewBindingGenerationFindi
               .joinToString("") { fragment -> fragment.capitalize() } + "Binding"
 
             // fully qualified
-            "$basePackage.databinding.$simpleBindingName".asExplicitReference()
+            "$basePackage.databinding.$simpleBindingName".asExplicitJavaReference()
           }
 
         val usedInProject = sourceSetName.withDownStream(project)

--- a/modulecheck-core/src/main/kotlin/modulecheck/core/rule/UnusedKaptRule.kt
+++ b/modulecheck-core/src/main/kotlin/modulecheck/core/rule/UnusedKaptRule.kt
@@ -27,9 +27,6 @@ import modulecheck.core.UnusedPluginFinding
 import modulecheck.core.kapt.UnusedKaptProcessorFinding
 import modulecheck.core.kapt.defaultKaptMatchers
 import modulecheck.parsing.source.Reference
-import modulecheck.parsing.source.Reference.ExplicitReference
-import modulecheck.parsing.source.Reference.InterpretedReference
-import modulecheck.parsing.source.Reference.UnqualifiedRReference
 import modulecheck.project.McProject
 import modulecheck.utils.LazySet
 import modulecheck.utils.any
@@ -113,14 +110,7 @@ class UnusedKaptRule(
     .any { annotationRegex ->
 
       references.any { referenceName ->
-
-        when (referenceName) {
-          is ExplicitReference -> annotationRegex.matches(referenceName.fqName)
-          is InterpretedReference -> {
-            referenceName.possibleNames.any { annotationRegex.matches(it) }
-          }
-          is UnqualifiedRReference -> annotationRegex.matches(referenceName.fqName)
-        }
+        annotationRegex.matches(referenceName.fqName)
       }
     }
 }

--- a/modulecheck-core/src/main/kotlin/modulecheck/core/rule/UnusedKotlinAndroidExtensionsRule.kt
+++ b/modulecheck-core/src/main/kotlin/modulecheck/core/rule/UnusedKotlinAndroidExtensionsRule.kt
@@ -19,7 +19,7 @@ import modulecheck.api.context.referencesForSourceSetName
 import modulecheck.api.rule.ModuleCheckRule
 import modulecheck.api.settings.ChecksSettings
 import modulecheck.core.UnusedPluginFinding
-import modulecheck.parsing.source.asExplicitReference
+import modulecheck.parsing.source.asExplicitKotlinReference
 import modulecheck.project.AndroidMcProject
 import modulecheck.project.McProject
 import modulecheck.utils.any
@@ -33,8 +33,8 @@ class UnusedKotlinAndroidExtensionsRule : ModuleCheckRule<UnusedPluginFinding> {
   override val description = "Finds modules which have Kotlin AndroidExtensions enabled, " +
     "but don't actually use any synthetic imports"
 
-  private val parcelizeImport = "kotlinx.android.parcel.Parcelize".asExplicitReference()
-  private val syntheticReferencePackage = "kotlinx.android.synthetic"
+  private val parcelizeImport = "kotlinx.android.parcel.Parcelize".asExplicitKotlinReference()
+  private val syntheticReferencePackage = "kotlinx.android.synthetic".asExplicitKotlinReference()
 
   override suspend fun check(project: McProject): List<UnusedPluginFinding> {
     val androidProject = project as? AndroidMcProject ?: return emptyList()

--- a/modulecheck-parsing/android/src/main/kotlin/modulecheck/parsing/android/XmlFile.kt
+++ b/modulecheck-parsing/android/src/main/kotlin/modulecheck/parsing/android/XmlFile.kt
@@ -18,8 +18,8 @@ package modulecheck.parsing.android
 import modulecheck.parsing.source.AndroidResource
 import modulecheck.parsing.source.HasReferences
 import modulecheck.parsing.source.Reference
-import modulecheck.parsing.source.Reference.UnqualifiedRReference
-import modulecheck.parsing.source.asExplicitReference
+import modulecheck.parsing.source.Reference.ExplicitXmlReference
+import modulecheck.parsing.source.Reference.UnqualifiedXmlAndroidResourceReference
 import modulecheck.utils.LazySet.DataSource
 import modulecheck.utils.asDataSource
 import modulecheck.utils.mapToSet
@@ -38,7 +38,7 @@ interface XmlFile : HasReferences {
     val name: String = file.nameWithoutExtension
 
     val customViews: Lazy<Set<Reference>> = lazy {
-      AndroidLayoutParser().parseViews(file).mapToSet { it.asExplicitReference() }
+      AndroidLayoutParser().parseViews(file).mapToSet { ExplicitXmlReference(it) }
     }
 
     private val rawResources: Set<String> by lazy {
@@ -59,7 +59,7 @@ interface XmlFile : HasReferences {
       return listOf(
         customViews.asDataSource(),
         lazy {
-          resourceReferencesAsRReferences.mapToSet { UnqualifiedRReference(it) }
+          resourceReferencesAsRReferences.mapToSet { UnqualifiedXmlAndroidResourceReference(it) }
         }.asDataSource()
       )
     }
@@ -90,7 +90,7 @@ interface XmlFile : HasReferences {
 
       return listOf(
         lazy {
-          resourceReferencesAsRReferences.mapToSet { UnqualifiedRReference(it) }
+          resourceReferencesAsRReferences.mapToSet { UnqualifiedXmlAndroidResourceReference(it) }
         }.asDataSource()
       )
     }

--- a/modulecheck-parsing/java/src/main/kotlin/modulecheck/parsing/java/ParsedFile.kt
+++ b/modulecheck-parsing/java/src/main/kotlin/modulecheck/parsing/java/ParsedFile.kt
@@ -22,6 +22,7 @@ import com.github.javaparser.ast.body.FieldDeclaration
 import com.github.javaparser.ast.body.MethodDeclaration
 import com.github.javaparser.ast.body.TypeDeclaration
 import com.github.javaparser.ast.type.ClassOrInterfaceType
+import modulecheck.parsing.source.AgnosticDeclarationName
 import modulecheck.parsing.source.DeclarationName
 import modulecheck.utils.mapToSet
 import org.jetbrains.kotlin.name.FqName
@@ -54,16 +55,16 @@ internal data class ParsedFile(
               is MethodDeclaration -> {
 
                 if (node.canBeImported()) {
-                  memberDeclarations.add(DeclarationName(node.fqName(typeDeclarations)))
+                  memberDeclarations.add(AgnosticDeclarationName(node.fqName(typeDeclarations)))
                 }
               }
               is FieldDeclaration -> {
                 if (node.canBeImported()) {
-                  memberDeclarations.add(DeclarationName(node.fqName(typeDeclarations)))
+                  memberDeclarations.add(AgnosticDeclarationName(node.fqName(typeDeclarations)))
                 }
               }
               is EnumConstantDeclaration -> {
-                enumDeclarations.add(DeclarationName(node.fqName(typeDeclarations)))
+                enumDeclarations.add(AgnosticDeclarationName(node.fqName(typeDeclarations)))
               }
             }
           }

--- a/modulecheck-parsing/java/src/test/kotlin/modulecheck/parsing/java/JavaFileTest.kt
+++ b/modulecheck-parsing/java/src/test/kotlin/modulecheck/parsing/java/JavaFileTest.kt
@@ -18,7 +18,7 @@ package modulecheck.parsing.java
 import kotlinx.coroutines.runBlocking
 import modulecheck.parsing.source.JavaVersion
 import modulecheck.parsing.source.JavaVersion.VERSION_14
-import modulecheck.parsing.source.Reference
+import modulecheck.parsing.source.asInterpretedJavaReference
 import modulecheck.project.test.ProjectTest
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Nested
@@ -294,9 +294,9 @@ internal class JavaFileTest :
         wildcardImports = setOf("com.lib1"),
         declarations = setOf("com.test.ParsedClass"),
         interpretedReferences = setOf(
-          Reference.InterpretedReference(
-            setOf("Lib1Class", "com.lib1.Lib1Class", "com.test.Lib1Class")
-          )
+          "Lib1Class".asInterpretedJavaReference(),
+          "com.lib1.Lib1Class".asInterpretedJavaReference(),
+          "com.test.Lib1Class".asInterpretedJavaReference()
         ),
         apiReferences = setOf("Lib1Class", "com.lib1.Lib1Class", "com.test.Lib1Class")
       )
@@ -320,9 +320,8 @@ internal class JavaFileTest :
         declarations = setOf("com.test.ParsedClass"),
         apiReferences = setOf("com.lib1.Lib1Class", "com.test.com.lib1.Lib1Class"),
         interpretedReferences = setOf(
-          Reference.InterpretedReference(
-            setOf("com.lib1.Lib1Class", "com.test.com.lib1.Lib1Class")
-          )
+          "com.lib1.Lib1Class".asInterpretedJavaReference(),
+          "com.test.com.lib1.Lib1Class".asInterpretedJavaReference()
         )
       )
     }
@@ -471,13 +470,9 @@ internal class JavaFileTest :
             "com.test.Lib1Class"
           ),
           interpretedReferences = setOf(
-            Reference.InterpretedReference(
-              setOf(
-                "Lib1Class",
-                "com.lib1.Lib1Class",
-                "com.test.Lib1Class"
-              )
-            )
+            "Lib1Class".asInterpretedJavaReference(),
+            "com.lib1.Lib1Class".asInterpretedJavaReference(),
+            "com.test.Lib1Class".asInterpretedJavaReference()
           )
         )
       }
@@ -535,13 +530,9 @@ internal class JavaFileTest :
             "com.test.Lib1Class"
           ),
           interpretedReferences = setOf(
-            Reference.InterpretedReference(
-              setOf(
-                "Lib1Class",
-                "com.lib1.Lib1Class",
-                "com.test.Lib1Class"
-              )
-            )
+            "Lib1Class".asInterpretedJavaReference(),
+            "com.lib1.Lib1Class".asInterpretedJavaReference(),
+            "com.test.Lib1Class".asInterpretedJavaReference()
           )
         )
       }

--- a/modulecheck-parsing/psi/src/main/kotlin/modulecheck/parsing/psi/FqNames.kt
+++ b/modulecheck-parsing/psi/src/main/kotlin/modulecheck/parsing/psi/FqNames.kt
@@ -19,4 +19,6 @@ import org.jetbrains.kotlin.name.FqName
 
 object FqNames {
   val inject = FqName("javax.inject.Inject")
+  val jvmField = FqName("kotlin.jvm.JvmField")
+  val jvmStatic = FqName("kotlin.jvm.JvmStatic")
 }

--- a/modulecheck-parsing/psi/src/main/kotlin/modulecheck/parsing/psi/ReferenceVisitor.kt
+++ b/modulecheck-parsing/psi/src/main/kotlin/modulecheck/parsing/psi/ReferenceVisitor.kt
@@ -20,7 +20,6 @@ import modulecheck.parsing.psi.internal.getChildrenOfTypeRecursive
 import modulecheck.parsing.psi.internal.hasAnnotation
 import modulecheck.parsing.psi.internal.isPartOf
 import modulecheck.parsing.psi.internal.isPrivateOrInternal
-import modulecheck.parsing.source.KotlinFile
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
@@ -43,9 +42,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getChildOfType
 import org.jetbrains.kotlin.psi.psiUtil.isFunctionalExpression
 
 @Suppress("TooManyFunctions")
-class ReferenceVisitor(
-  private val kotlinFile: KotlinFile
-) : KtTreeVisitorVoid() {
+class ReferenceVisitor : KtTreeVisitorVoid() {
 
   internal val qualifiedExpressions: MutableSet<PsiElement> = mutableSetOf()
   internal val callableReferences: MutableSet<PsiElement> = mutableSetOf()
@@ -92,7 +89,7 @@ class ReferenceVisitor(
 
       apiReferences += valueTypeRefs
 
-      if (constructor.hasAnnotation(kotlinFile, FqNames.inject)) {
+      if (constructor.hasAnnotation(FqNames.inject)) {
         constructorInjected += valueTypeRefs
       }
 
@@ -108,7 +105,7 @@ class ReferenceVisitor(
 
       apiReferences += valueTypeRefs
 
-      if (constructor.hasAnnotation(kotlinFile, FqNames.inject)) {
+      if (constructor.hasAnnotation(FqNames.inject)) {
         constructorInjected += valueTypeRefs
       }
 

--- a/modulecheck-parsing/psi/src/main/kotlin/modulecheck/parsing/psi/internal/ktCallableDeclaration.kt
+++ b/modulecheck-parsing/psi/src/main/kotlin/modulecheck/parsing/psi/internal/ktCallableDeclaration.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2021-2022 Rick Busarow
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package modulecheck.parsing.psi.internal
+
+import modulecheck.parsing.psi.FqNames
+import modulecheck.utils.capitalize
+import modulecheck.utils.unsafeLazy
+import org.jetbrains.kotlin.psi.KtAnnotated
+import org.jetbrains.kotlin.psi.KtCallableDeclaration
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtPropertyAccessor
+import org.jetbrains.kotlin.psi.KtValueArgumentList
+
+fun KtCallableDeclaration.isJvmStatic(): Boolean {
+  return hasAnnotation(FqNames.jvmStatic)
+}
+
+fun KtProperty.isJvmField(): Boolean {
+  return hasAnnotation(FqNames.jvmField)
+}
+
+fun KtFunction.jvmNameOrNull(): String? = annotatedJvmNameOrNull()
+
+fun KtPropertyAccessor.jvmNameOrNull(): String? = annotatedJvmNameOrNull()
+
+private fun KtAnnotated.annotatedJvmNameOrNull(): String? {
+  return annotationEntries
+    .firstOrNull { it.shortName?.asString() == "JvmName" }
+    ?.getChildrenOfTypeRecursive<KtValueArgumentList>()
+    ?.single()
+    ?.getChildrenOfTypeRecursive<KtLiteralStringTemplateEntry>()
+    ?.single()
+    ?.text
+}
+
+internal fun KtPropertyAccessor.jvmSimpleName(): String {
+  jvmNameOrNull()?.let { return it }
+
+  val prefix = if (isGetter) "get" else "set"
+
+  val suffix = property.nameAsSafeName.identifier.capitalize()
+
+  return prefix + suffix
+}
+
+/**
+ * Returns any custom names defined by `@JvmName(...)`, the default setter/getter names if it's a
+ * property, or the same names as used by Kotlin for anything else.
+ */
+internal fun KtNamedDeclaration.jvmSimpleNames(): Set<String> {
+  return when (this) {
+    is KtFunction -> {
+      setOf(jvmNameOrNull() ?: nameAsSafeName.asString())
+    }
+    is KtProperty -> {
+
+      // const properties can't have JvmName annotations
+      if (isConst()) return emptySet()
+
+      val suffix by unsafeLazy { nameAsSafeName.identifier.capitalize() }
+
+      setOfNotNull(
+        getter?.jvmNameOrNull() ?: "get$suffix",
+        if (isVar) {
+          setter?.jvmNameOrNull() ?: "set$suffix"
+        } else null
+      )
+    }
+    else -> {
+      setOf(nameAsSafeName.asString())
+    }
+  }
+}

--- a/modulecheck-parsing/source/src/main/kotlin/modulecheck/parsing/source/AnvilGradlePlugin.kt
+++ b/modulecheck-parsing/source/src/main/kotlin/modulecheck/parsing/source/AnvilGradlePlugin.kt
@@ -15,6 +15,7 @@
 
 package modulecheck.parsing.source
 
+import modulecheck.parsing.source.Reference.ExplicitKotlinReference
 import net.swiftzer.semver.SemVer
 import org.jetbrains.kotlin.name.FqName
 
@@ -37,4 +38,4 @@ data class AnvilScopeName(val fqName: FqName) {
   override fun toString(): String = fqName.asString()
 }
 
-data class AnvilScopeNameEntry(val name: String)
+data class AnvilScopeNameEntry(val name: ExplicitKotlinReference)

--- a/modulecheck-parsing/source/src/main/kotlin/modulecheck/parsing/source/JvmFile.kt
+++ b/modulecheck-parsing/source/src/main/kotlin/modulecheck/parsing/source/JvmFile.kt
@@ -15,12 +15,12 @@
 
 package modulecheck.parsing.source
 
+import modulecheck.parsing.source.Reference.ExplicitReference
 import modulecheck.utils.LazyDeferred
 import modulecheck.utils.LazySet.DataSource
 import modulecheck.utils.LazySet.DataSource.Priority.HIGH
 import modulecheck.utils.LazySet.DataSource.Priority.LOW
 import modulecheck.utils.asDataSource
-import org.jetbrains.kotlin.name.FqName
 
 sealed interface JvmFile : HasReferences {
   val name: String
@@ -28,6 +28,7 @@ sealed interface JvmFile : HasReferences {
   val declarations: Set<DeclarationName>
 
   val importsLazy: Lazy<Set<Reference>>
+  val apiReferences: LazyDeferred<Set<Reference>>
   val interpretedReferencesLazy: Lazy<Set<Reference>>
 
   override fun references(): List<DataSource<Reference>> {
@@ -41,11 +42,9 @@ sealed interface JvmFile : HasReferences {
 
 interface KotlinFile : JvmFile {
 
-  val apiReferences: LazyDeferred<Set<String>>
-
   fun getScopeArguments(
-    allAnnotations: Set<String>,
-    mergeAnnotations: Set<String>
+    allAnnotations: List<ExplicitReference>,
+    mergeAnnotations: List<ExplicitReference>
   ): ScopeArgumentParseResult
 
   data class ScopeArgumentParseResult(
@@ -54,9 +53,7 @@ interface KotlinFile : JvmFile {
   )
 }
 
-interface JavaFile : JvmFile {
-  val apiReferences: Set<FqName>
-}
+interface JavaFile : JvmFile
 
 enum class JavaVersion {
   VERSION_1_1,

--- a/modulecheck-parsing/source/src/main/kotlin/modulecheck/parsing/source/NamedSymbol.kt
+++ b/modulecheck-parsing/source/src/main/kotlin/modulecheck/parsing/source/NamedSymbol.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2021-2022 Rick Busarow
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package modulecheck.parsing.source
+
+import modulecheck.parsing.source.Reference.ExplicitKotlinReference
+
+sealed interface NamedSymbol {
+  val fqName: String
+
+  fun startsWith(symbol: NamedSymbol): Boolean {
+    return fqName.startsWith(symbol.fqName)
+  }
+
+  fun startingWith(str: String): List<String> {
+    return if (fqName.startsWith(str)) {
+      listOf(fqName)
+    } else {
+      listOf()
+    }
+  }
+
+  fun startingWith(symbol: NamedSymbol): List<String> {
+    return if (fqName.startsWith(symbol.fqName)) {
+      listOf(fqName)
+    } else {
+      listOf()
+    }
+  }
+
+  fun endsWith(str: String): Boolean {
+    return fqName.endsWith(str)
+  }
+
+  fun endsWith(symbol: NamedSymbol): Boolean {
+    return fqName.endsWith(symbol.fqName)
+  }
+
+  fun endsWith(str: ExplicitKotlinReference): Boolean {
+    return fqName.endsWith(str.fqName)
+  }
+
+  fun endingWith(symbol: NamedSymbol): List<String> {
+    return if (fqName.endsWith(symbol.fqName)) {
+      listOf(fqName)
+    } else {
+      listOf()
+    }
+  }
+
+  fun endingWith(str: ExplicitKotlinReference): List<String> {
+    return if (fqName.endsWith(str.fqName)) {
+      listOf(fqName)
+    } else {
+      listOf()
+    }
+  }
+}

--- a/modulecheck-project/api/src/testFixtures/kotlin/modulecheck/project/test/ProjectTest.kt
+++ b/modulecheck-project/api/src/testFixtures/kotlin/modulecheck/project/test/ProjectTest.kt
@@ -28,7 +28,7 @@ import modulecheck.parsing.gradle.ConfigurationName
 import modulecheck.parsing.gradle.SourceSetName
 import modulecheck.parsing.source.Reference.ExplicitReference
 import modulecheck.parsing.source.Reference.InterpretedReference
-import modulecheck.parsing.source.Reference.UnqualifiedRReference
+import modulecheck.parsing.source.Reference.UnqualifiedAndroidResourceReference
 import modulecheck.project.AndroidMcProject
 import modulecheck.project.ConfiguredProjectDependency
 import modulecheck.project.McProject
@@ -224,7 +224,7 @@ abstract class ProjectTest : BaseTest() {
             val referenceName = when (reference) {
               is ExplicitReference -> reference.fqName
               is InterpretedReference -> return@eachRef
-              is UnqualifiedRReference -> reference.fqName
+              is UnqualifiedAndroidResourceReference -> reference.fqName
             }
 
             // Only check for references which would be provided by internal projects. Using a

--- a/modulecheck-utils/src/main/kotlin/modulecheck/utils/LazySetImpl.kt
+++ b/modulecheck-utils/src/main/kotlin/modulecheck/utils/LazySetImpl.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2021-2022 Rick Busarow
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package modulecheck.utils
+
+import kotlinx.coroutines.flow.AbstractFlow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
+import java.util.concurrent.atomic.AtomicReference
+
+internal class LazySetImpl<E>(
+  cache: Set<E>,
+  sources: List<LazySet.DataSource<E>>
+) : AbstractFlow<E>(), LazySet<E> {
+
+  internal val state = AtomicReference(
+    LazySet.State(
+      cache = cache, remaining = sources
+    )
+  )
+
+  override val isFullyCached: Boolean
+    get() = state.get().remaining.isEmpty()
+
+  override fun snapshot(): LazySet.State<E> = state.get()
+
+  override suspend fun contains(element: Any?): Boolean {
+
+    val snap = state.get()
+
+    return (
+      snap.cache.contains(element) || snap.remainingFlow()
+        .any { it.contains(element) }
+      )
+  }
+
+  private fun updateCache(new: Set<E>, completed: List<LazySet.DataSource<E>>) {
+
+    var fromAtomic: LazySet.State<E>
+    var newPair: LazySet.State<E>
+
+    do {
+      fromAtomic = state.get()
+      newPair = LazySet.State(
+        cache = fromAtomic.cache + new,
+        remaining = fromAtomic.remaining.minus(completed.toSet())
+      )
+    } while (!state.compareAndSet(fromAtomic, newPair))
+  }
+
+  private fun LazySet.State<E>.remainingFlow(): Flow<Set<E>> {
+
+    return nextSources().asFlow()
+      .map { nextSources ->
+
+        nextSources.mapAsync { it.get() }
+          .flatMapSetConcat { it }
+          .also { newData -> updateCache(newData, nextSources) }
+      }
+  }
+
+  override suspend fun collectSafely(collector: FlowCollector<E>) {
+
+    val snap = state.get()
+
+    val additionalCache = mutableSetOf<E>()
+    val completed: MutableList<LazySet.DataSource<E>> = mutableListOf()
+
+    val distinctFlow = flow {
+
+      emitAll(snap.cache.asFlow())
+
+      @Suppress("MagicNumber")
+      snap.remaining.sorted()
+        .chunked(100)
+        .forEach { dataProviderChunk ->
+
+          val new = dataProviderChunk
+            .mapAsync { provider -> provider.get() }
+            .flatMapSetConcat { it }
+
+          additionalCache.addAll(new)
+          completed.addAll(dataProviderChunk)
+
+          emitAll(new.asFlow())
+        }
+    }
+      .distinct()
+      .onCompletion { updateCache(additionalCache, completed) }
+
+    collector.emitAll(distinctFlow)
+  }
+}

--- a/modulecheck-utils/src/main/kotlin/modulecheck/utils/flow.kt
+++ b/modulecheck-utils/src/main/kotlin/modulecheck/utils/flow.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.fold
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.toSet
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
@@ -43,6 +44,11 @@ fun <T> Flow<T>.distinct(): Flow<T> = flow {
 
 suspend fun <T> Flow<T>.contains(element: T): Boolean {
   return any { it == element }
+}
+
+suspend fun <T> Flow<T>.containsAny(elements: Collection<T>): Boolean {
+  val elementsSet = elements as? Set<T> ?: toSet()
+  return any { it in elementsSet }
 }
 
 suspend fun <T, R> Flow<T>.flatMapListConcat(


### PR DESCRIPTION
For instance,

```kotlin
package com.example

object Utils {
  fun doSomething() = Unit
}
```
In Kotlin, the function's fqName is `com.example.Utils.doSomething`.
In Java, the name is `com.example.Utils.INSTANCE.doSomething`.