### PR TITLE
rename `moduleAccess` to `projectAccessor`

### DIFF
--- a/modulecheck-parsing/gradle/src/main/kotlin/modulecheck/parsing/gradle/DependenciesBlock.kt
+++ b/modulecheck-parsing/gradle/src/main/kotlin/modulecheck/parsing/gradle/DependenciesBlock.kt
@@ -81,13 +81,13 @@ abstract class DependenciesBlock(
 
   /**
    * @param moduleRef `:my:project:lib1` or `my.project.lib1`
-   * @param moduleAccess `project(:my:project:lib1)` or `projects.my.project.lib1`
+   * @param projectAccessor `project(:my:project:lib1)` or `projects.my.project.lib1`
    */
   fun addModuleStatement(
     configName: ConfigurationName,
     parsedString: String,
     moduleRef: ModuleRef,
-    moduleAccess: String,
+    projectAccessor: String,
     suppressed: List<String>
   ) {
     val cm = ConfiguredModule(configName = configName, moduleRef = moduleRef)
@@ -96,7 +96,7 @@ abstract class DependenciesBlock(
 
     val declaration = ModuleDependencyDeclaration(
       moduleRef = moduleRef,
-      moduleAccess = moduleAccess,
+      projectAccessor = projectAccessor,
       configName = configName,
       declarationText = parsedString,
       statementWithSurroundingText = originalString,

--- a/modulecheck-parsing/gradle/src/main/kotlin/modulecheck/parsing/gradle/DependencyDeclaration.kt
+++ b/modulecheck-parsing/gradle/src/main/kotlin/modulecheck/parsing/gradle/DependencyDeclaration.kt
@@ -63,7 +63,7 @@ data class UnknownDependencyDeclaration(
 
 data class ModuleDependencyDeclaration(
   val moduleRef: ModuleRef,
-  val moduleAccess: String,
+  val projectAccessor: String,
   override val configName: ConfigurationName,
   override val declarationText: String,
   override val statementWithSurroundingText: String,
@@ -133,13 +133,13 @@ data class ModuleDependencyDeclaration(
     testFixtures: Boolean
   ): String {
 
-    val escapedModuleAccess = Regex.escape(moduleAccess)
-    val regex = "testFixtures\\s*\\(\\s*$escapedModuleAccess\\s*\\)".toRegex()
+    val escapedProjectAccessor = Regex.escape(projectAccessor)
+    val regex = "testFixtures\\s*\\(\\s*$escapedProjectAccessor\\s*\\)".toRegex()
 
     return when {
       testFixtures && regex.containsMatchIn(this) -> this
       testFixtures -> "testFixtures($this)"
-      else -> replace(regex, moduleAccess)
+      else -> replace(regex, projectAccessor)
     }
   }
 
@@ -150,7 +150,7 @@ data class ModuleDependencyDeclaration(
     other as ModuleDependencyDeclaration
 
     if (moduleRef != other.moduleRef) return false
-    if (moduleAccess != other.moduleAccess) return false
+    if (projectAccessor != other.projectAccessor) return false
     if (configName != other.configName) return false
     if (declarationText != other.declarationText) return false
     if (statementWithSurroundingText != other.statementWithSurroundingText) return false
@@ -161,7 +161,7 @@ data class ModuleDependencyDeclaration(
 
   override fun hashCode(): Int {
     var result = moduleRef.hashCode()
-    result = 31 * result + moduleAccess.hashCode()
+    result = 31 * result + projectAccessor.hashCode()
     result = 31 * result + configName.hashCode()
     result = 31 * result + declarationText.hashCode()
     result = 31 * result + statementWithSurroundingText.hashCode()

--- a/modulecheck-parsing/gradle/src/testFixtures/kotlin/modulecheck/parsing/gradle/ReportingLogger.kt
+++ b/modulecheck-parsing/gradle/src/testFixtures/kotlin/modulecheck/parsing/gradle/ReportingLogger.kt
@@ -33,18 +33,18 @@ fun UnknownDependencyDeclaration(
 @Suppress("LongParameterList")
 fun ModuleDependencyDeclaration(
   moduleRef: ModuleRef,
-  moduleAccess: String,
+  projectAccessor: String,
   configName: ConfigurationName,
   declarationText: String,
   statementWithSurroundingText: String,
   suppressed: List<String> = emptyList()
 ): ModuleDependencyDeclaration = ModuleDependencyDeclaration(
-  moduleRef,
-  moduleAccess,
-  configName,
-  declarationText,
-  statementWithSurroundingText,
-  suppressed
+  moduleRef = moduleRef,
+  projectAccessor = projectAccessor,
+  configName = configName,
+  declarationText = declarationText,
+  statementWithSurroundingText = statementWithSurroundingText,
+  suppressed = suppressed
 ) { it.value }
 
 @Suppress("LongParameterList")

--- a/modulecheck-parsing/groovy-antlr/src/main/kotlin/modulecheck/parsing/groovy/antlr/GroovyDependencyBlockParser.kt
+++ b/modulecheck-parsing/groovy-antlr/src/main/kotlin/modulecheck/parsing/groovy/antlr/GroovyDependencyBlockParser.kt
@@ -190,12 +190,12 @@ class GroovyDependencyBlockParser @Inject constructor() {
               val moduleNamePair = projectDepVisitor.visit(ctx)
 
               if (moduleNamePair != null) {
-                val (moduleAccess, moduleRef) = moduleNamePair
+                val (projectAccessor, moduleRef) = moduleNamePair
                 dependenciesBlock.addModuleStatement(
                   configName = config.asConfigurationName(),
                   parsedString = ctx.originalText(),
                   moduleRef = ModuleRef.from(moduleRef),
-                  moduleAccess = moduleAccess,
+                  projectAccessor = projectAccessor,
                   suppressed = suppressed
                 )
                 return

--- a/modulecheck-parsing/groovy-antlr/src/test/kotlin/modulecheck/parsing/groovy/antlr/GroovyDependencyBlockParserTest.kt
+++ b/modulecheck-parsing/groovy-antlr/src/test/kotlin/modulecheck/parsing/groovy/antlr/GroovyDependencyBlockParserTest.kt
@@ -64,14 +64,14 @@ internal class GroovyDependencyBlockParserTest : BaseTest() {
     getOrEmpty(ModuleRef.StringRef(":core:jvm"), ConfigurationName.api) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = "project(':core:jvm')",
+        projectAccessor = "project(':core:jvm')",
         configName = ConfigurationName.api,
         declarationText = """api project(':core:jvm')""",
         statementWithSurroundingText = """   api project(':core:jvm') // trailing comment"""
       ),
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = "project(':core:jvm')",
+        projectAccessor = "project(':core:jvm')",
         configName = ConfigurationName.api,
         declarationText = """api project(':core:jvm')""",
         statementWithSurroundingText = """   api project(':core:jvm')"""
@@ -94,7 +94,7 @@ internal class GroovyDependencyBlockParserTest : BaseTest() {
     settings shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:android"),
-        moduleAccess = "project(':core:android')",
+        projectAccessor = "project(':core:android')",
         configName = ConfigurationName.api,
         declarationText = """api project(':core:android')""",
         statementWithSurroundingText = "  api project(':core:android')",
@@ -102,7 +102,7 @@ internal class GroovyDependencyBlockParserTest : BaseTest() {
       ),
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = "project(':core:jvm')",
+        projectAccessor = "project(':core:jvm')",
         configName = ConfigurationName.api,
         declarationText = """api project(':core:jvm')""",
         statementWithSurroundingText = "  //noinspection Unused, MustBeApi\n  api project(':core:jvm')",
@@ -110,7 +110,7 @@ internal class GroovyDependencyBlockParserTest : BaseTest() {
       ),
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:test"),
-        moduleAccess = "project(':core:test')",
+        projectAccessor = "project(':core:test')",
         configName = ConfigurationName.testImplementation,
         declarationText = """testImplementation project(':core:test')""",
         statementWithSurroundingText = "  testImplementation project(':core:test')",
@@ -137,7 +137,7 @@ internal class GroovyDependencyBlockParserTest : BaseTest() {
       settings shouldBe listOf(
         ModuleDependencyDeclaration(
           moduleRef = StringRef(":core:android"),
-          moduleAccess = "project(':core:android')",
+          projectAccessor = "project(':core:android')",
           configName = ConfigurationName.api,
           declarationText = """api project(':core:android')""",
           statementWithSurroundingText = "  api project(':core:android')",
@@ -145,7 +145,7 @@ internal class GroovyDependencyBlockParserTest : BaseTest() {
         ),
         ModuleDependencyDeclaration(
           moduleRef = StringRef(":core:jvm"),
-          moduleAccess = "project(':core:jvm')",
+          projectAccessor = "project(':core:jvm')",
           configName = ConfigurationName.api,
           declarationText = """api project(':core:jvm')""",
           statementWithSurroundingText = "  //noinspection InheritedDependency\n  api project(':core:jvm')",
@@ -166,7 +166,7 @@ internal class GroovyDependencyBlockParserTest : BaseTest() {
     settings shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = "project(':core:jvm')",
+        projectAccessor = "project(':core:jvm')",
         configName = ConfigurationName.api,
         declarationText = """api testFixtures(project(':core:jvm'))""",
         statementWithSurroundingText = """   api testFixtures(project(':core:jvm'))"""
@@ -186,7 +186,7 @@ internal class GroovyDependencyBlockParserTest : BaseTest() {
     settings shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = TypeSafeRef("core.jvm"),
-        moduleAccess = "projects.core.jvm",
+        projectAccessor = "projects.core.jvm",
         configName = ConfigurationName.api,
         declarationText = """api testFixtures(projects.core.jvm)""",
         statementWithSurroundingText = """  api testFixtures(projects.core.jvm)"""
@@ -213,7 +213,7 @@ internal class GroovyDependencyBlockParserTest : BaseTest() {
     ) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:test"),
-        moduleAccess = "project(':core:test')",
+        projectAccessor = "project(':core:test')",
         configName = ConfigurationName.api,
         declarationText = """api project(':core:test') {
         |    exclude group: 'androidx.appcompat'
@@ -229,7 +229,7 @@ internal class GroovyDependencyBlockParserTest : BaseTest() {
     getOrEmpty(":core:jvm", ConfigurationName.api) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = "project(':core:jvm')",
+        projectAccessor = "project(':core:jvm')",
         configName = ConfigurationName.api,
         declarationText = "api project(':core:jvm')",
         statementWithSurroundingText = "\n  api project(':core:jvm')"
@@ -254,7 +254,7 @@ internal class GroovyDependencyBlockParserTest : BaseTest() {
       getOrEmpty(":core:test", ConfigurationName.api) shouldBe listOf(
         ModuleDependencyDeclaration(
           moduleRef = StringRef(":core:test"),
-          moduleAccess = "project(':core:test')",
+          projectAccessor = "project(':core:test')",
           configName = ConfigurationName.api,
           declarationText = """api project(':core:test') {
           |    exclude group: 'androidx.appcompat'
@@ -272,7 +272,7 @@ internal class GroovyDependencyBlockParserTest : BaseTest() {
       getOrEmpty(":core:jvm", ConfigurationName.api) shouldBe listOf(
         ModuleDependencyDeclaration(
           moduleRef = StringRef(":core:jvm"),
-          moduleAccess = "project(':core:jvm')",
+          projectAccessor = "project(':core:jvm')",
           configName = ConfigurationName.api,
           declarationText = "api project(':core:jvm')",
           statementWithSurroundingText = "  api project(':core:jvm')"
@@ -294,7 +294,7 @@ internal class GroovyDependencyBlockParserTest : BaseTest() {
     getOrEmpty(":core:jvm", ConfigurationName.api) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = "project(':core:jvm')",
+        projectAccessor = "project(':core:jvm')",
         configName = ConfigurationName.api,
         declarationText = "api project(':core:jvm')",
         statementWithSurroundingText = "\n   api project(':core:jvm')"
@@ -315,7 +315,7 @@ internal class GroovyDependencyBlockParserTest : BaseTest() {
     getOrEmpty(":core:jvm", ConfigurationName.api) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = "project(':core:jvm')",
+        projectAccessor = "project(':core:jvm')",
         configName = ConfigurationName.api,
         declarationText = """api project(':core:jvm')""",
         statementWithSurroundingText = """   api project(':core:jvm')"""
@@ -325,7 +325,7 @@ internal class GroovyDependencyBlockParserTest : BaseTest() {
     getOrEmpty(":core:jvm", ConfigurationName.implementation) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = "project(':core:jvm')",
+        projectAccessor = "project(':core:jvm')",
         configName = ConfigurationName.implementation,
         declarationText = """implementation project(':core:jvm')""",
         statementWithSurroundingText = """   implementation project(':core:jvm')"""
@@ -348,7 +348,7 @@ internal class GroovyDependencyBlockParserTest : BaseTest() {
     getOrEmpty(":core:android", ConfigurationName.implementation) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:android"),
-        moduleAccess = "project(':core:android')",
+        projectAccessor = "project(':core:android')",
         configName = ConfigurationName.implementation,
         declarationText = """implementation project(':core:android')""",
         statementWithSurroundingText = """
@@ -377,7 +377,7 @@ internal class GroovyDependencyBlockParserTest : BaseTest() {
     getOrEmpty(":core:android", ConfigurationName.implementation) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:android"),
-        moduleAccess = "project(':core:android')",
+        projectAccessor = "project(':core:android')",
         configName = ConfigurationName.implementation,
         declarationText = """implementation project(':core:android')""",
         statementWithSurroundingText = """
@@ -404,7 +404,7 @@ internal class GroovyDependencyBlockParserTest : BaseTest() {
     getOrEmpty(":core:android", ConfigurationName.implementation) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:android"),
-        moduleAccess = "project(':core:android')",
+        projectAccessor = "project(':core:android')",
         configName = ConfigurationName.implementation,
         declarationText = """implementation project(':core:android')""",
         statementWithSurroundingText = """   /* single-line block comment */ implementation project(':core:android')"""
@@ -425,14 +425,14 @@ internal class GroovyDependencyBlockParserTest : BaseTest() {
     getOrEmpty(":core:jvm", ConfigurationName.api) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = "project(':core:jvm')",
+        projectAccessor = "project(':core:jvm')",
         configName = ConfigurationName.api,
         declarationText = """api project(':core:jvm')""",
         statementWithSurroundingText = """  api project(':core:jvm')"""
       ),
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = "project(':core:jvm')",
+        projectAccessor = "project(':core:jvm')",
         configName = ConfigurationName.api,
         declarationText = """api project(':core:jvm')""",
         statementWithSurroundingText = """  api project(':core:jvm')"""
@@ -453,7 +453,7 @@ internal class GroovyDependencyBlockParserTest : BaseTest() {
     getOrEmpty(":core:test", ConfigurationName.api) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = TypeSafeRef("core.test"),
-        moduleAccess = "projects.core.test",
+        projectAccessor = "projects.core.test",
         configName = ConfigurationName.api,
         declarationText = """api projects.core.test""",
         statementWithSurroundingText = """  api projects.core.test"""
@@ -463,7 +463,7 @@ internal class GroovyDependencyBlockParserTest : BaseTest() {
     getOrEmpty(":http-logging", ConfigurationName.implementation) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = TypeSafeRef("httpLogging"),
-        moduleAccess = "projects.httpLogging",
+        projectAccessor = "projects.httpLogging",
         configName = ConfigurationName.implementation,
         declarationText = """implementation projects.httpLogging""",
         statementWithSurroundingText = """  implementation projects.httpLogging"""

--- a/modulecheck-parsing/psi/src/main/kotlin/modulecheck/parsing/psi/KotlinDependencyBlockParser.kt
+++ b/modulecheck-parsing/psi/src/main/kotlin/modulecheck/parsing/psi/KotlinDependencyBlockParser.kt
@@ -106,12 +106,12 @@ private fun KtCallExpression.parseStatements(
 
   if (moduleNamePair != null) {
 
-    val (moduleAccess, moduleRef) = moduleNamePair
+    val (projectAccessor, moduleRef) = moduleNamePair
     block.addModuleStatement(
       configName = configName.asConfigurationName(),
       parsedString = text,
       moduleRef = ModuleRef.from(moduleRef),
-      moduleAccess = moduleAccess,
+      projectAccessor = projectAccessor,
       suppressed = suppressed
     )
     return
@@ -134,13 +134,13 @@ private fun KtCallExpression.parseStatements(
 
   if (testFixturesModuleNamePair != null) {
 
-    val (moduleAccess, moduleRef) = testFixturesModuleNamePair
+    val (projectAccessor, moduleRef) = testFixturesModuleNamePair
 
     block.addModuleStatement(
       configName = configName.asConfigurationName(),
       parsedString = text,
       moduleRef = ModuleRef.from(moduleRef),
-      moduleAccess = moduleAccess,
+      projectAccessor = projectAccessor,
       suppressed = suppressed
     )
     return
@@ -161,17 +161,17 @@ internal fun KtCallExpression.getStringModuleNameOrNull(): Pair<String, String>?
     .valueArguments                                       // [project(path = ":foo:bar")]
     .firstOrNull()                                        // project(path = ":foo:bar")
     ?.getChildOfType<KtCallExpression>()                  // project(path = ":foo:bar")
-    ?.let { moduleAccessCallExpression ->
+    ?.let { projectAccessorCallExpression ->
 
-      val moduleAccess = moduleAccessCallExpression.text
+      val projectAccessor = projectAccessorCallExpression.text
 
-      moduleAccessCallExpression
+      projectAccessorCallExpression
         .valueArguments                                   // [path = ":foo:bar"]
         .firstOrNull()                                    // path = ":foo:bar"
         ?.getChildOfType<KtStringTemplateExpression>()    // ":foo:bar"
         ?.getChildOfType<KtLiteralStringTemplateEntry>()  // :foo:bar
         ?.text
-        ?.let { moduleRef -> moduleAccess to moduleRef }
+        ?.let { moduleRef -> projectAccessor to moduleRef }
     }
 }
 
@@ -180,14 +180,14 @@ internal fun KtCallExpression.getTypeSafeModuleNameOrNull(): Pair<String, String
     .valueArguments                                 // [projects.foo.bar]
     .firstOrNull()                                  // projects.foo.bar
     ?.getChildOfType<KtDotQualifiedExpression>()    // projects.foo.bar
-    ?.let { moduleAccessCallExpression ->
+    ?.let { projectAccessorCallExpression ->
 
-      val moduleAccess = moduleAccessCallExpression.text
+      val projectAccessor = projectAccessorCallExpression.text
 
-      moduleAccessCallExpression.text
+      projectAccessorCallExpression.text
         ?.takeIf { it.startsWith("projects.") }
         ?.removePrefix("projects.")
-        ?.let { moduleRef -> moduleAccess to moduleRef }
+        ?.let { moduleRef -> projectAccessor to moduleRef }
     }
 }
 
@@ -199,17 +199,17 @@ internal fun KtCallExpression.getStringTestFixturesModuleNameOrNull(): Pair<Stri
     ?.valueArguments                                      // [project(path = ":foo:bar")]
     ?.firstOrNull()                                       // project(path = ":foo:bar")
     ?.getChildOfType<KtCallExpression>()                  // project(path = ":foo:bar")
-    ?.let { moduleAccessCallExpression ->
+    ?.let { projectAccessorCallExpression ->
 
-      val moduleAccess = moduleAccessCallExpression.text
+      val projectAccessor = projectAccessorCallExpression.text
 
-      moduleAccessCallExpression
+      projectAccessorCallExpression
         .valueArguments                                   // [path = ":foo:bar"]
         .firstOrNull()                                    // path = ":foo:bar"
         ?.getChildOfType<KtStringTemplateExpression>()    // ":foo:bar"
         ?.getChildOfType<KtLiteralStringTemplateEntry>()  // :foo:bar
         ?.text
-        ?.let { moduleRef -> moduleAccess to moduleRef }
+        ?.let { moduleRef -> projectAccessor to moduleRef }
     }
 }
 
@@ -221,15 +221,15 @@ internal fun KtCallExpression.getTypeSafeTestFixturesModuleNameOrNull(): Pair<St
     ?.valueArguments                                // [projects.foo.bar]
     ?.firstOrNull()                                 // projects.foo.bar
     ?.getChildOfType<KtDotQualifiedExpression>()    // projects.foo.bar
-    ?.let { moduleAccessCallExpression ->
+    ?.let { projectAccessorCallExpression ->
 
-      val moduleAccess = moduleAccessCallExpression.text
+      val projectAccessor = projectAccessorCallExpression.text
 
-      moduleAccessCallExpression
+      projectAccessorCallExpression
         .text
         ?.takeIf { it.startsWith("projects.") }
         ?.removePrefix("projects.")
-        ?.let { moduleRef -> moduleAccess to moduleRef }
+        ?.let { moduleRef -> projectAccessor to moduleRef }
     }
 }
 

--- a/modulecheck-parsing/psi/src/test/kotlin/modulecheck/parsing/psi/KotlinDependencyBlockParserTest.kt
+++ b/modulecheck-parsing/psi/src/test/kotlin/modulecheck/parsing/psi/KotlinDependencyBlockParserTest.kt
@@ -65,7 +65,7 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
     block.settings shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = """project(path = ":core:jvm")""",
+        projectAccessor = """project(path = ":core:jvm")""",
         configName = ConfigurationName.api,
         declarationText = """"api"(project(path = ":core:jvm"))""",
         statementWithSurroundingText = """  "api"(project(path = ":core:jvm"))"""
@@ -88,14 +88,14 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
     block.getOrEmpty(":core:jvm", ConfigurationName.api) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = """project(":core:jvm")""",
+        projectAccessor = """project(":core:jvm")""",
         configName = ConfigurationName.api,
         declarationText = """api(project(":core:jvm"))""",
         statementWithSurroundingText = """   api(project(":core:jvm")) // trailing comment"""
       ),
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = """project(":core:jvm")""",
+        projectAccessor = """project(":core:jvm")""",
         configName = ConfigurationName.api,
         declarationText = """api(project(":core:jvm"))""",
         statementWithSurroundingText = """   api(project(":core:jvm"))"""
@@ -120,7 +120,7 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
     block.settings shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:android"),
-        moduleAccess = """project(":core:android")""",
+        projectAccessor = """project(":core:android")""",
         configName = ConfigurationName.api,
         declarationText = """api(project(":core:android"))""",
         statementWithSurroundingText = "   api(project(\":core:android\"))",
@@ -128,7 +128,7 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
       ),
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = """project(":core:jvm")""",
+        projectAccessor = """project(":core:jvm")""",
         configName = ConfigurationName.api,
         declarationText = """api(project(":core:jvm"))""",
         statementWithSurroundingText = "   @Suppress(\"Unused\")\n   api(project(\":core:jvm\"))",
@@ -136,7 +136,7 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
       ),
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:test"),
-        moduleAccess = """project(":core:test")""",
+        projectAccessor = """project(":core:test")""",
         configName = ConfigurationName.testImplementation,
         declarationText = """testImplementation(project(":core:test"))""",
         statementWithSurroundingText = "   testImplementation(project(\":core:test\"))",
@@ -163,7 +163,7 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
     block.settings shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:android"),
-        moduleAccess = """project(":core:android")""",
+        projectAccessor = """project(":core:android")""",
         configName = ConfigurationName.api,
         declarationText = """api(project(":core:android"))""",
         statementWithSurroundingText = "   api(project(\":core:android\"))",
@@ -171,7 +171,7 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
       ),
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = """project(":core:jvm")""",
+        projectAccessor = """project(":core:jvm")""",
         configName = ConfigurationName.api,
         declarationText = """api(project(":core:jvm"))""",
         statementWithSurroundingText = "   @Suppress(\"InheritedDependency\")\n   api(project(\":core:jvm\"))",
@@ -179,7 +179,7 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
       ),
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:test"),
-        moduleAccess = """project(":core:test")""",
+        projectAccessor = """project(":core:test")""",
         configName = ConfigurationName.testImplementation,
         declarationText = """testImplementation(project(":core:test"))""",
         statementWithSurroundingText = "   testImplementation(project(\":core:test\"))",
@@ -205,14 +205,14 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
     block.settings shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":lib1"),
-        moduleAccess = """project(":lib1")""",
+        projectAccessor = """project(":lib1")""",
         configName = ConfigurationName.api,
         declarationText = """api(testFixtures(project(":lib1")))""",
         statementWithSurroundingText = """   api(testFixtures(project(":lib1")))"""
       ),
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":lib2"),
-        moduleAccess = """project(":lib2")""",
+        projectAccessor = """project(":lib2")""",
         configName = ConfigurationName.api,
         declarationText = """api(testFixtures(project(":lib2")))""",
         statementWithSurroundingText = """|
@@ -221,7 +221,7 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
       ),
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":lib3"),
-        moduleAccess = """project(":lib3")""",
+        projectAccessor = """project(":lib3")""",
         configName = ConfigurationName.implementation,
         declarationText = """implementation(testFixtures(project(":lib3")))""",
         statementWithSurroundingText = """   implementation(testFixtures(project(":lib3")))"""
@@ -243,7 +243,7 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
     block.settings shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = """project(":core:jvm")""",
+        projectAccessor = """project(":core:jvm")""",
         configName = ConfigurationName.api,
         declarationText = """api(testFixtures(project(":core:jvm")))""",
         statementWithSurroundingText = """   api(testFixtures(project(":core:jvm")))"""
@@ -265,7 +265,7 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
     block.settings shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = TypeSafeRef("core.jvm"),
-        moduleAccess = "projects.core.jvm",
+        projectAccessor = "projects.core.jvm",
         configName = ConfigurationName.api,
         declarationText = """api(testFixtures(projects.core.jvm))""",
         statementWithSurroundingText = """   api(testFixtures(projects.core.jvm))"""
@@ -291,7 +291,7 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
     block.getOrEmpty(":core:test", ConfigurationName.api) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:test"),
-        moduleAccess = """project(":core:test")""",
+        projectAccessor = """project(":core:test")""",
         configName = ConfigurationName.api,
         declarationText = """api(project(":core:test")) {
           |     exclude(group = "androidx.appcompat")
@@ -308,7 +308,7 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
     block.getOrEmpty(":core:jvm", ConfigurationName.api) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = """project(":core:jvm")""",
+        projectAccessor = """project(":core:jvm")""",
         configName = ConfigurationName.api,
         declarationText = "api(project(\":core:jvm\"))",
         statementWithSurroundingText = "\n   api(project(\":core:jvm\"))"
@@ -334,7 +334,7 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
     block.getOrEmpty(":core:test", ConfigurationName.api) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:test"),
-        moduleAccess = """project(":core:test")""",
+        projectAccessor = """project(":core:test")""",
         configName = ConfigurationName.api,
         declarationText = """api(project(":core:test")) {
           |     exclude(group = "androidx.appcompat")
@@ -352,7 +352,7 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
     block.getOrEmpty(":core:jvm", ConfigurationName.api) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = """project(":core:jvm")""",
+        projectAccessor = """project(":core:jvm")""",
         configName = ConfigurationName.api,
         declarationText = "api(project(\":core:jvm\"))",
         statementWithSurroundingText = "   api(project(\":core:jvm\"))"
@@ -376,7 +376,7 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
     block.getOrEmpty(":core:jvm", ConfigurationName.api) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = """project(":core:jvm")""",
+        projectAccessor = """project(":core:jvm")""",
         configName = ConfigurationName.api,
         declarationText = "api(project(\":core:jvm\"))",
         statementWithSurroundingText = "\n   api(project(\":core:jvm\"))"
@@ -399,7 +399,7 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
     block.getOrEmpty(":core:jvm", ConfigurationName.api) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = """project(":core:jvm")""",
+        projectAccessor = """project(":core:jvm")""",
         configName = ConfigurationName.api,
         declarationText = """api(project(":core:jvm"))""",
         statementWithSurroundingText = """   api(project(":core:jvm"))"""
@@ -409,7 +409,7 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
     block.getOrEmpty(":core:jvm", ConfigurationName.implementation) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = """project(":core:jvm")""",
+        projectAccessor = """project(":core:jvm")""",
         configName = ConfigurationName.implementation,
         declarationText = """implementation(project(":core:jvm"))""",
         statementWithSurroundingText = """   implementation(project(":core:jvm"))"""
@@ -434,7 +434,7 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
     block.getOrEmpty(":core:android", ConfigurationName.implementation) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:android"),
-        moduleAccess = """project(":core:android")""",
+        projectAccessor = """project(":core:android")""",
         configName = ConfigurationName.implementation,
         declarationText = """implementation(project(":core:android"))""",
         statementWithSurroundingText = """
@@ -465,7 +465,7 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
     block.getOrEmpty(":core:android", ConfigurationName.implementation) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:android"),
-        moduleAccess = """project(":core:android")""",
+        projectAccessor = """project(":core:android")""",
         configName = ConfigurationName.implementation,
         declarationText = """implementation(project(":core:android"))""",
         statementWithSurroundingText = """
@@ -494,7 +494,7 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
     block.getOrEmpty(":core:android", ConfigurationName.implementation) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:android"),
-        moduleAccess = """project(":core:android")""",
+        projectAccessor = """project(":core:android")""",
         configName = ConfigurationName.implementation,
         declarationText = """implementation(project(":core:android"))""",
         statementWithSurroundingText = """   /* single-line block comment */ implementation(project(":core:android"))"""
@@ -517,14 +517,14 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
     block.getOrEmpty(":core:jvm", ConfigurationName.api) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = """project(":core:jvm")""",
+        projectAccessor = """project(":core:jvm")""",
         configName = ConfigurationName.api,
         declarationText = """api(project(":core:jvm"))""",
         statementWithSurroundingText = """   api(project(":core:jvm"))"""
       ),
       ModuleDependencyDeclaration(
         moduleRef = StringRef(":core:jvm"),
-        moduleAccess = """project(":core:jvm")""",
+        projectAccessor = """project(":core:jvm")""",
         configName = ConfigurationName.api,
         declarationText = """api (   project(":core:jvm"))""",
         statementWithSurroundingText = """   api (   project(":core:jvm"))"""
@@ -547,7 +547,7 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
     block.getOrEmpty(":core:test", ConfigurationName.api) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = TypeSafeRef("core.test"),
-        moduleAccess = "projects.core.test",
+        projectAccessor = "projects.core.test",
         configName = ConfigurationName.api,
         declarationText = """api(projects.core.test)""",
         statementWithSurroundingText = """   api(projects.core.test)"""
@@ -557,7 +557,7 @@ internal class KotlinDependencyBlockParserTest : ProjectTest() {
     block.getOrEmpty(":http-logging", ConfigurationName.implementation) shouldBe listOf(
       ModuleDependencyDeclaration(
         moduleRef = TypeSafeRef("httpLogging"),
-        moduleAccess = "projects.httpLogging",
+        projectAccessor = "projects.httpLogging",
         configName = ConfigurationName.implementation,
         declarationText = """implementation(projects.httpLogging)""",
         statementWithSurroundingText = """   implementation(projects.httpLogging)"""


### PR DESCRIPTION
I was just looking at this property for the first time in several months, and I definitely didn't know what it was just from its name.