### PR TITLE
don't generate BuildConfig if it's ignored in Android settings

### DIFF
--- a/modulecheck-plugin/src/main/kotlin/modulecheck/gradle/ModuleCheckPlugin.kt
+++ b/modulecheck-plugin/src/main/kotlin/modulecheck/gradle/ModuleCheckPlugin.kt
@@ -24,6 +24,7 @@ import modulecheck.core.rule.MultiRuleFindingFactory
 import modulecheck.core.rule.SingleRuleFindingFactory
 import modulecheck.core.rule.SortDependenciesRule
 import modulecheck.core.rule.SortPluginsRule
+import modulecheck.gradle.internal.generatesBuildConfig
 import modulecheck.gradle.internal.isMissingManifestFile
 import modulecheck.gradle.task.ModuleCheckTask
 import org.gradle.api.Plugin
@@ -95,6 +96,7 @@ class ModuleCheckPlugin : Plugin<Project> {
           .forEach { mcTask.dependsOn(it) }
 
         allprojects
+          .filter { it.generatesBuildConfig() }
           .flatMap { it.tasks.withType(GenerateBuildConfig::class.java) }
           .forEach { mcTask.dependsOn(it) }
       }

--- a/modulecheck-plugin/src/main/kotlin/modulecheck/gradle/internal/project.kt
+++ b/modulecheck-plugin/src/main/kotlin/modulecheck/gradle/internal/project.kt
@@ -15,6 +15,9 @@
 
 package modulecheck.gradle.internal
 
+import com.android.build.api.dsl.DynamicFeatureExtension
+import com.android.build.gradle.LibraryExtension
+import com.android.build.gradle.TestExtension
 import com.android.build.gradle.TestedExtension
 import modulecheck.parsing.gradle.SourceSetName
 import modulecheck.parsing.gradle.asSourceSetName
@@ -69,4 +72,19 @@ fun Project.isMissingManifestFile(): Boolean {
     // the file must be declared, but not exist in order for this to be triggered
     ?.let { !it.exists() }
     ?: false
+}
+
+/**
+ * @return true if the project is an Android library, dynamic feature, or test extensions module and
+ *   BuildConfig generation has NOT been explicitly disabled.
+ */
+fun Project.generatesBuildConfig(): Boolean {
+  @Suppress("UnstableApiUsage")
+  return extensions.findByType(LibraryExtension::class.java)
+    ?.let { it.buildFeatures.buildConfig != false }
+    ?: extensions.findByType(DynamicFeatureExtension::class.java)
+      ?.let { it.buildFeatures.buildConfig != false }
+    ?: extensions.findByType(TestExtension::class.java)
+      ?.let { it.buildFeatures.buildConfig != false }
+    ?: true
 }

--- a/modulecheck-plugin/src/test/kotlin/modulecheck/gradle/AndroidBuildConfigAvoidanceTest.kt
+++ b/modulecheck-plugin/src/test/kotlin/modulecheck/gradle/AndroidBuildConfigAvoidanceTest.kt
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2021-2022 Rick Busarow
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package modulecheck.gradle
+
+import modulecheck.specs.DEFAULT_AGP_VERSION
+import modulecheck.specs.DEFAULT_KOTLIN_VERSION
+import modulecheck.testing.createSafely
+import modulecheck.utils.child
+import org.junit.jupiter.api.Test
+
+class AndroidBuildConfigAvoidanceTest : BasePluginTest() {
+
+  @Test
+  fun `buildConfig task should be required when not configured in android library module`() {
+    androidProject(":", "com.modulecheck.lib1") {
+      buildFile {
+        """
+        plugins {
+          id("com.android.library") version "$DEFAULT_AGP_VERSION"
+          kotlin("android") version "$DEFAULT_KOTLIN_VERSION"
+          id("com.rickbusarow.module-check")
+        }
+        repositories {
+          mavenCentral()
+          google()
+          jcenter()
+          maven("https://plugins.gradle.org/m2/")
+          maven("https://oss.sonatype.org/content/repositories/snapshots")
+        }
+
+        android {
+          defaultConfig {
+            minSdkVersion(23)
+            compileSdkVersion(30)
+            targetSdkVersion(30)
+          }
+        }
+        """
+      }
+
+      projectDir.child("settings.gradle.kts").createSafely()
+    }
+
+    shouldSucceed("moduleCheck").apply {
+      // Assert that nothing else executed.
+      // If ModuleCheck were relying upon buildConfig tasks, they'd be in this list.
+      tasks.map { it.path } shouldBe listOf(
+        ":preBuild",
+        ":preDebugAndroidTestBuild",
+        ":preDebugBuild",
+        ":extractDeepLinksDebug",
+        ":processDebugManifest",
+        ":generateDebugBuildConfig",
+        ":preReleaseBuild",
+        ":generateReleaseBuildConfig",
+        ":processDebugAndroidTestManifest",
+        ":generateDebugAndroidTestBuildConfig",
+        ":moduleCheck"
+      )
+    }
+  }
+
+  @Test
+  fun `buildConfig task should not be required when disabled in android library module`() {
+    androidProject(":", "com.modulecheck.lib1") {
+      buildFile {
+        """
+        plugins {
+          id("com.android.library") version "$DEFAULT_AGP_VERSION"
+          kotlin("android") version "$DEFAULT_KOTLIN_VERSION"
+          id("com.rickbusarow.module-check")
+        }
+        repositories {
+          mavenCentral()
+          google()
+          jcenter()
+          maven("https://plugins.gradle.org/m2/")
+          maven("https://oss.sonatype.org/content/repositories/snapshots")
+        }
+
+        android {
+          defaultConfig {
+            minSdkVersion(23)
+            compileSdkVersion(30)
+            targetSdkVersion(30)
+          }
+          buildFeatures.buildConfig = false
+        }
+        """
+      }
+
+      projectDir.child("settings.gradle.kts").createSafely()
+    }
+
+    shouldSucceed("moduleCheck").apply {
+      // Assert that nothing else executed.
+      // If ModuleCheck were relying upon buildConfig tasks, they'd be in this list.
+      tasks.map { it.path } shouldBe listOf(":moduleCheck")
+    }
+  }
+
+  @Test
+  fun `buildConfig task should not be required when disabled in android dynamic-feature module`() {
+    androidProject(":", "com.modulecheck.lib1") {
+      buildFile {
+        """
+        plugins {
+          id("com.android.dynamic-feature") version "$DEFAULT_AGP_VERSION"
+          kotlin("android") version "$DEFAULT_KOTLIN_VERSION"
+          id("com.rickbusarow.module-check")
+        }
+        repositories {
+          mavenCentral()
+          google()
+          jcenter()
+          maven("https://plugins.gradle.org/m2/")
+          maven("https://oss.sonatype.org/content/repositories/snapshots")
+        }
+
+        android {
+          defaultConfig {
+            minSdkVersion(23)
+            compileSdkVersion(30)
+          }
+          buildFeatures.buildConfig = false
+        }
+        """
+      }
+
+      projectDir.child("settings.gradle.kts").createSafely()
+    }
+
+    shouldSucceed("moduleCheck").apply {
+      // Assert that nothing else executed.
+      // If ModuleCheck were relying upon buildConfig tasks, they'd be in this list.
+      tasks.map { it.path } shouldBe listOf(":moduleCheck")
+    }
+  }
+
+  @Test
+  fun `buildConfig task should not be required when disabled in android test module`() {
+    androidProject(":", "com.modulecheck.lib1") {
+      buildFile {
+        """
+        plugins {
+          id("com.android.test") version "$DEFAULT_AGP_VERSION"
+          kotlin("android") version "$DEFAULT_KOTLIN_VERSION"
+          id("com.rickbusarow.module-check")
+        }
+        allprojects {
+          repositories {
+            mavenCentral()
+            google()
+            jcenter()
+            maven("https://plugins.gradle.org/m2/")
+            maven("https://oss.sonatype.org/content/repositories/snapshots")
+          }
+        }
+
+        android {
+          targetProjectPath = ":app"
+          defaultConfig {
+            minSdkVersion(23)
+            compileSdkVersion(30)
+            targetSdkVersion(30)
+          }
+          buildFeatures.buildConfig = false
+        }
+
+        moduleCheck {
+          // this is a compileOnly dependency for test modules
+          ignoreUnusedFinding = setOf(":app")
+        }
+        """
+      }
+
+      projectDir.child("settings.gradle.kts").createSafely(
+        """
+        include(":app")
+        """.trimIndent()
+      )
+    }
+
+    androidProject(":app", "com.modulecheck.app") {
+      buildFile {
+        """
+        plugins {
+          id("com.android.library")
+          kotlin("android")
+        }
+
+        android {
+          defaultConfig {
+            minSdkVersion(23)
+            compileSdkVersion(30)
+            targetSdkVersion(30)
+          }
+          buildFeatures.buildConfig = false
+        }
+        """
+      }
+    }
+
+    shouldSucceed("moduleCheck").apply {
+      // Assert that nothing else executed.
+      // If ModuleCheck were relying upon buildConfig tasks, they'd be in this list.
+      tasks.map { it.path } shouldBe listOf(":moduleCheck")
+    }
+  }
+}


### PR DESCRIPTION
fixes #453