### PR TITLE
remove deprecated `project` and `androidProject` functions

### DIFF
--- a/modulecheck-core/src/test/kotlin/modulecheck/core/CheckstyleReportingTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/CheckstyleReportingTest.kt
@@ -44,7 +44,7 @@ internal class CheckstyleReportingTest : RunnerTest() {
       findingFactory = findingFactory(
         listOf(
           CouldUseAnvilFinding(
-            dependentProject = project(":lib1"),
+            dependentProject = kotlinProject(":lib1"),
             buildFile = testProjectDir
           )
         )
@@ -81,7 +81,7 @@ internal class CheckstyleReportingTest : RunnerTest() {
       findingFactory = findingFactory(
         listOf(
           CouldUseAnvilFinding(
-            dependentProject = project(":lib1"),
+            dependentProject = kotlinProject(":lib1"),
             buildFile = testProjectDir
           )
         )

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/ConsoleReportingTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/ConsoleReportingTest.kt
@@ -49,7 +49,7 @@ internal class ConsoleReportingTest : RunnerTest() {
       findingFactory = findingFactory(
         listOf(
           CouldUseAnvilFinding(
-            dependentProject = project(":lib1"),
+            dependentProject = kotlinProject(":lib1"),
             buildFile = File(testProjectDir, "lib1/build.gradle.kts")
           )
         )
@@ -76,11 +76,11 @@ internal class ConsoleReportingTest : RunnerTest() {
       findingFactory = findingFactory(
         listOf(
           CouldUseAnvilFinding(
-            dependentProject = project(":lib1"),
+            dependentProject = kotlinProject(":lib1"),
             buildFile = File(testProjectDir, "lib1/build.gradle.kts")
           ),
           CouldUseAnvilFinding(
-            dependentProject = project(":lib2"),
+            dependentProject = kotlinProject(":lib2"),
             buildFile = File(testProjectDir, "lib2/build.gradle.kts")
           )
         )
@@ -111,7 +111,7 @@ internal class ConsoleReportingTest : RunnerTest() {
       findingFactory = findingFactory(
         listOf(
           CouldUseAnvilFinding(
-            dependentProject = project(":lib1"),
+            dependentProject = kotlinProject(":lib1"),
             buildFile = File(testProjectDir, "lib1/build.gradle.kts")
           )
         )
@@ -143,7 +143,7 @@ internal class ConsoleReportingTest : RunnerTest() {
       findingFactory = findingFactory(
         listOf(
           CouldUseAnvilFinding(
-            dependentProject = project(":lib1"),
+            dependentProject = kotlinProject(":lib1"),
             buildFile = File(testProjectDir, "lib1/build.gradle.kts")
           )
         )
@@ -174,7 +174,7 @@ internal class ConsoleReportingTest : RunnerTest() {
       findingFactory = findingFactory(
         listOf(
           CouldUseAnvilFinding(
-            dependentProject = project(":lib1"),
+            dependentProject = kotlinProject(":lib1"),
             buildFile = File(testProjectDir, "lib1/build.gradle.kts")
           )
         )

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/DepthOutputTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/DepthOutputTest.kt
@@ -30,13 +30,13 @@ internal class DepthOutputTest : RunnerTest() {
   @Test
   fun `main source set depths should be reported`() {
 
-    val lib1 = project(":lib1")
+    val lib1 = kotlinProject(":lib1")
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
     }
 
-    project(":app") {
+    kotlinProject(":app") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib2)
     }
@@ -64,9 +64,9 @@ internal class DepthOutputTest : RunnerTest() {
 
     settings.checks.depths = true
 
-    val lib1 = project(":lib1")
+    val lib1 = kotlinProject(":lib1")
 
-    project(":lib2") {
+    kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -108,13 +108,13 @@ internal class DepthOutputTest : RunnerTest() {
   @Test
   fun `test source set depths should not be reported`() {
 
-    val lib1 = project(":lib1")
+    val lib1 = kotlinProject(":lib1")
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
     }
 
-    project(":app") {
+    kotlinProject(":app") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib2)
     }
@@ -142,18 +142,18 @@ internal class DepthOutputTest : RunnerTest() {
   @Test
   fun `debug source set depth should not be reported even if it's longer`() {
 
-    val lib1 = project(":lib1")
-    val debug1 = project(":debug1")
+    val lib1 = kotlinProject(":lib1")
+    val debug1 = kotlinProject(":debug1")
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
     }
-    val debug2 = project(":debug2") {
+    val debug2 = kotlinProject(":debug2") {
       addDependency(ConfigurationName.implementation, debug1)
       addDependency(ConfigurationName.implementation, lib2)
     }
 
-    project(":app") {
+    kotlinProject(":app") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib2)
       addDependency(ConfigurationName("debugImplementation"), debug2)

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/DepthReportTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/DepthReportTest.kt
@@ -43,13 +43,13 @@ internal class DepthReportTest : RunnerTest() {
 
     settings.reports.depths.enabled = false
 
-    val lib1 = project(":lib1")
+    val lib1 = kotlinProject(":lib1")
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
     }
 
-    project(":app") {
+    kotlinProject(":app") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib2)
     }
@@ -64,13 +64,13 @@ internal class DepthReportTest : RunnerTest() {
 
     settings.reports.depths.enabled = true
 
-    val lib1 = project(":lib1")
+    val lib1 = kotlinProject(":lib1")
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
     }
 
-    project(":app") {
+    kotlinProject(":app") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib2)
     }
@@ -96,15 +96,15 @@ internal class DepthReportTest : RunnerTest() {
 
     settings.reports.depths.enabled = true
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource("src/main/kotlin/MyFile.kt", "")
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
     }
 
-    project(":app") {
+    kotlinProject(":app") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib2)
     }
@@ -134,13 +134,13 @@ internal class DepthReportTest : RunnerTest() {
 
     settings.reports.depths.enabled = true
 
-    val lib1 = project(":lib1")
+    val lib1 = kotlinProject(":lib1")
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
     }
 
-    project(":app") {
+    kotlinProject(":app") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib2)
     }
@@ -166,15 +166,15 @@ internal class DepthReportTest : RunnerTest() {
 
     settings.reports.depths.enabled = true
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       maybeAddSourceSet(SourceSetName.TEST)
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
     }
 
-    project(":app") {
+    kotlinProject(":app") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib2)
     }
@@ -207,7 +207,7 @@ internal class DepthReportTest : RunnerTest() {
     settings.checks.depths = true
     settings.reports.depths.enabled = true
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
 
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
@@ -219,7 +219,7 @@ internal class DepthReportTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       addSource(
@@ -244,7 +244,7 @@ internal class DepthReportTest : RunnerTest() {
       }
     }
 
-    project(":app") {
+    kotlinProject(":app") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib2)
 
@@ -310,20 +310,20 @@ internal class DepthReportTest : RunnerTest() {
 
     settings.reports.depths.enabled = true
 
-    val lib1 = project(":lib1")
-    val debug1 = project(":debug1") {
+    val lib1 = kotlinProject(":lib1")
+    val debug1 = kotlinProject(":debug1") {
       addDependency(ConfigurationName.implementation, lib1)
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
     }
-    val debug2 = project(":debug2") {
+    val debug2 = kotlinProject(":debug2") {
       addDependency(ConfigurationName.implementation, debug1)
       addDependency(ConfigurationName.implementation, lib2)
     }
 
-    project(":app") {
+    kotlinProject(":app") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib2)
       addSourceSet(SourceSetName("debug"))

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/DisableAndroidResourcesTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/DisableAndroidResourcesTest.kt
@@ -29,7 +29,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `resource generation is used in contributing module with no changes`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -70,7 +70,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `resource generation is used in dependent module with no changes`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -92,7 +92,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
       )
     }
 
-    androidProject(":lib2", "com.modulecheck.lib2") {
+    androidLibrary(":lib2", "com.modulecheck.lib2") {
       addDependency(ConfigurationName.api, lib1)
       platformPlugin.androidResourcesEnabled = false
 
@@ -125,7 +125,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `unused resource generation without autocorrect should fail and be reported`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -155,7 +155,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `unused resource generation when scoped and then qualified should be fixed`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -191,7 +191,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `unused resource generation without buildFeatures block should be fixed`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -230,7 +230,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `unused resource generation without android block should add android block under existing plugins block`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -266,7 +266,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `unused resource generation without android or plugins block should add android block above dependencies block`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         apply(plugin = "com.android.library")
@@ -304,7 +304,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `unused resource generation when fully qualified should be fixed`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -336,7 +336,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `unused resource generation when qualified and then scoped should be fixed`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -372,7 +372,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `unused resource generation when fully scoped should be fixed`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -412,7 +412,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `unused resource generation with autocorrect and no explicit buildFeatures property should be fixed`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -448,7 +448,7 @@ class DisableAndroidResourcesTest : RunnerTest() {
   @Test
   fun `unused resource generation with autocorrect and no android block should be fixed`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/DisableViewBindingTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/DisableViewBindingTest.kt
@@ -33,7 +33,7 @@ class DisableViewBindingTest : RunnerTest() {
   @Test
   fun `used ViewBinding from main sourceset in dependent module with no changes`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -59,7 +59,7 @@ class DisableViewBindingTest : RunnerTest() {
       )
     }
 
-    androidProject(":lib2", "com.modulecheck.lib2") {
+    androidLibrary(":lib2", "com.modulecheck.lib2") {
       addDependency(ConfigurationName.api, lib1)
       platformPlugin.viewBindingEnabled = false
 
@@ -96,7 +96,7 @@ class DisableViewBindingTest : RunnerTest() {
   @Test
   fun `used ViewBinding from debug sourceset in dependent module with no changes`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -123,7 +123,7 @@ class DisableViewBindingTest : RunnerTest() {
       )
     }
 
-    androidProject(":lib2", "com.modulecheck.lib2") {
+    androidLibrary(":lib2", "com.modulecheck.lib2") {
       addDependency("debugImplementation".asConfigurationName(), lib1)
       platformPlugin.viewBindingEnabled = false
 
@@ -161,7 +161,7 @@ class DisableViewBindingTest : RunnerTest() {
   @Test
   fun `used ViewBinding in contributing module`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -219,7 +219,7 @@ class DisableViewBindingTest : RunnerTest() {
   @Test
   fun `ViewBinding from main is used in debug source set`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -285,7 +285,7 @@ class DisableViewBindingTest : RunnerTest() {
   @Test
   fun `ViewBinding from debug with different base package is used in debug source set`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -349,7 +349,7 @@ class DisableViewBindingTest : RunnerTest() {
   @Test
   fun `ViewBinding from debug without different base package is used in debug source set`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -414,7 +414,7 @@ class DisableViewBindingTest : RunnerTest() {
 
     settings.checks.disableViewBinding = false
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -461,7 +461,7 @@ class DisableViewBindingTest : RunnerTest() {
   @Test
   fun `unused ViewBinding without auto-correct should fail`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -510,7 +510,7 @@ class DisableViewBindingTest : RunnerTest() {
   @Test
   fun `unused ViewBinding when scoped and then qualified should be fixed`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -546,7 +546,7 @@ class DisableViewBindingTest : RunnerTest() {
   @Test
   fun `unused ViewBinding without buildFeatures block should be fixed`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -583,7 +583,7 @@ class DisableViewBindingTest : RunnerTest() {
   @Test
   fun `unused ViewBinding without android block should add android block under existing plugins block`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -617,7 +617,7 @@ class DisableViewBindingTest : RunnerTest() {
   @Test
   fun `unused ViewBinding without android or plugins block should add android block above dependencies block`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         apply(plugin = "com.android.library")
@@ -653,7 +653,7 @@ class DisableViewBindingTest : RunnerTest() {
   @Test
   fun `unused ViewBinding when fully qualified should be fixed`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -696,7 +696,7 @@ class DisableViewBindingTest : RunnerTest() {
   @Test
   fun `unused ViewBinding when fully scoped should be fixed`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -747,7 +747,7 @@ class DisableViewBindingTest : RunnerTest() {
   @Test
   fun `unused ViewBinding when qualified and then scoped should be fixed`() {
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/GraphVizReportTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/GraphVizReportTest.kt
@@ -45,13 +45,13 @@ internal class GraphVizReportTest : RunnerTest() {
 
     settings.reports.graphs.enabled = false
 
-    val lib1 = project(":lib1")
+    val lib1 = kotlinProject(":lib1")
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
     }
 
-    project(":app") {
+    kotlinProject(":app") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib2)
     }
@@ -66,13 +66,13 @@ internal class GraphVizReportTest : RunnerTest() {
 
     settings.reports.graphs.enabled = true
 
-    val lib1 = project(":lib1")
+    val lib1 = kotlinProject(":lib1")
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
     }
 
-    val app = project(":app") {
+    val app = kotlinProject(":app") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib2)
     }
@@ -105,7 +105,7 @@ internal class GraphVizReportTest : RunnerTest() {
 
     settings.reports.graphs.enabled = true
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource("src/main/kotlin/MyFile.kt", "")
     }
 
@@ -128,7 +128,7 @@ internal class GraphVizReportTest : RunnerTest() {
 
     settings.reports.graphs.enabled = true
 
-    val lib1 = project(":lib1")
+    val lib1 = kotlinProject(":lib1")
 
     run(autoCorrect = false).isSuccess shouldBe true
 
@@ -140,20 +140,20 @@ internal class GraphVizReportTest : RunnerTest() {
 
     settings.reports.graphs.enabled = true
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       maybeAddSourceSet(SourceSetName.TEST)
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
     }
 
-    val test1 = project(":test1") {
+    val test1 = kotlinProject(":test1") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib2)
     }
 
-    val app = project(":app") {
+    val app = kotlinProject(":app") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib2)
       addDependency(ConfigurationName.testImplementation, test1)
@@ -230,20 +230,20 @@ internal class GraphVizReportTest : RunnerTest() {
 
     settings.reports.graphs.enabled = true
 
-    val lib1 = project(":lib1")
-    val debug1 = project(":debug1") {
+    val lib1 = kotlinProject(":lib1")
+    val debug1 = kotlinProject(":debug1") {
       addDependency(ConfigurationName.implementation, lib1)
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
     }
-    val debug2 = project(":debug2") {
+    val debug2 = kotlinProject(":debug2") {
       addDependency(ConfigurationName.implementation, debug1)
       addDependency(ConfigurationName.implementation, lib2)
     }
 
-    val app = project(":app") {
+    val app = kotlinProject(":app") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib2)
       addDependency(ConfigurationName("debugImplementation"), debug1)

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/InheritedDependenciesTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/InheritedDependenciesTest.kt
@@ -31,7 +31,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited from api dependency without auto-correct should fail`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -42,7 +42,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -68,7 +68,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addDependency(ConfigurationName.api, lib2)
 
       buildFile {
@@ -126,10 +126,10 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `not inherited when source only declares as implementation config`() {
 
-    // A Kotlin build of this project would actually fail since :lib1 isn't in :lib3's classpath,
+    // A Kotlin build of this kotlinProject would actually fail since :lib1 isn't in :lib3's classpath,
     // but the test is still useful since it's just assuring that behavior is consistent
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -140,7 +140,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -168,7 +168,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addDependency(ConfigurationName.api, lib2)
 
       buildFile {
@@ -217,7 +217,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `not inherited when target and subject are the same`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
 
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
@@ -231,7 +231,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.testImplementation, lib1)
 
       buildFile {
@@ -285,7 +285,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited from api dependency with auto-correct should be fixed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -296,7 +296,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -322,7 +322,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addDependency(ConfigurationName.api, lib2)
 
       buildFile {
@@ -379,7 +379,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited as api from invisible dependency with a visible unrelated api project dependency`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -390,7 +390,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -416,7 +416,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
 
       buildFile {
         """
@@ -435,7 +435,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib4 = project(":lib4") {
+    val lib4 = kotlinProject(":lib4") {
       // lib2 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file
@@ -498,7 +498,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited as api from invisible dependency with a visible unrelated implementation project dependency`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -509,7 +509,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -535,7 +535,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
 
       buildFile {
         """
@@ -554,7 +554,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib4 = project(":lib4") {
+    val lib4 = kotlinProject(":lib4") {
       // lib2 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file
@@ -617,7 +617,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited as implementation from invisible dependency with a visible unrelated api project dependency`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -628,7 +628,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -654,7 +654,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
 
       buildFile {
         """
@@ -673,7 +673,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib4 = project(":lib4") {
+    val lib4 = kotlinProject(":lib4") {
       // lib2 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file
@@ -736,7 +736,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited as implementation from invisible dependency with a visible unrelated implementation project dependency`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -747,7 +747,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -773,7 +773,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
 
       buildFile {
         """
@@ -792,7 +792,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib4 = project(":lib4") {
+    val lib4 = kotlinProject(":lib4") {
       // lib2 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file
@@ -855,7 +855,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited as implementation from invisible dependency with an empty multi-line dependencies block`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -866,7 +866,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -892,7 +892,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       // lib2 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file
@@ -952,7 +952,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited as implementation from invisible dependency with an empty single-line dependencies block`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -963,7 +963,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -989,7 +989,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       // lib2 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file
@@ -1048,7 +1048,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited as implementation from invisible dependency with no dependencies block`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1059,7 +1059,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -1085,7 +1085,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       // lib2 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file
@@ -1142,7 +1142,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited as implementation from invisible dependency with only external implementation dependency`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1153,7 +1153,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -1179,7 +1179,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       // lib2 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file
@@ -1241,7 +1241,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited as implementation from invisible dependency with only external api dependency`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1252,7 +1252,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -1278,7 +1278,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       // lib2 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file
@@ -1340,7 +1340,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited as internalImplementation from internalApi dependency with auto-correct should be fixed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1351,7 +1351,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -1377,7 +1377,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addDependency("internalApi".asConfigurationName(), lib2)
 
       buildFile {
@@ -1445,7 +1445,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited as in main but also used in debug should only be added to main`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1456,7 +1456,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -1482,7 +1482,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addDependency(ConfigurationName.api, lib2)
 
       buildFile {
@@ -1550,7 +1550,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited as implementation in debug should be added to debug`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1562,7 +1562,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency("debugApi".asConfigurationName(), lib1)
 
       buildFile {
@@ -1589,7 +1589,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = androidProject(":lib3", "com.modulecheck.lib3") {
+    val lib3 = androidLibrary(":lib3", "com.modulecheck.lib3") {
       addDependency("debugImplementation".asConfigurationName(), lib2)
 
       buildFile {
@@ -1657,7 +1657,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited as internalImplementation from api dependency with auto-correct should be fixed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1668,7 +1668,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -1694,7 +1694,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addDependency(ConfigurationName.api, lib2)
       addSourceSet(SourceSetName("internal"), upstreamNames = listOf(SourceSetName.MAIN))
 
@@ -1771,7 +1771,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited into mid-level source set should not also be added to downstream source sets`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1782,7 +1782,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -1808,7 +1808,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addDependency(ConfigurationName.api, lib2)
       addSourceSet(SourceSetName("middle"), upstreamNames = listOf(SourceSetName.MAIN))
       addSourceSet(
@@ -1893,7 +1893,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `non-standard config name should be invoked as function if it's already used that way`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1904,7 +1904,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -1930,7 +1930,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
 
       addSourceSet("internal".asSourceSetName(), upstreamNames = listOf(SourceSetName.MAIN))
 
@@ -1991,7 +1991,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited via testApi should not cause infinite loop`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
 
       buildFile {
         """
@@ -2017,7 +2017,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.testApi, lib1)
 
       buildFile {
@@ -2082,7 +2082,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited from implementation dependency with auto-correct should be fixed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -2093,7 +2093,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -2119,7 +2119,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addDependency(ConfigurationName.implementation, lib2)
 
       buildFile {
@@ -2176,7 +2176,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited implementation from implementation with string extension should be added with string invocation`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -2187,7 +2187,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -2213,7 +2213,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addDependency(ConfigurationName.implementation, lib2)
 
       buildFile {
@@ -2270,7 +2270,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited implementation from api with string extension should be added with precompiled function`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -2281,7 +2281,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -2307,7 +2307,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addDependency(ConfigurationName.api, lib2)
 
       buildFile {
@@ -2364,7 +2364,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited novel debugImplementation in android project should use precompiled function`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -2375,7 +2375,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -2401,7 +2401,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = androidProject(":lib3", "com.modulecheck.lib3") {
+    val lib3 = androidLibrary(":lib3", "com.modulecheck.lib3") {
       addDependency(ConfigurationName.api, lib2)
 
       buildFile {
@@ -2467,7 +2467,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited novel androidTestDebugImplementation in android project should use precompiled function`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -2478,7 +2478,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -2504,7 +2504,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = androidProject(":lib3", "com.modulecheck.lib3") {
+    val lib3 = androidLibrary(":lib3", "com.modulecheck.lib3") {
       addDependency(ConfigurationName.api, lib2)
 
       buildFile {
@@ -2570,7 +2570,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited from implementation dependency and part of API with auto-correct should be fixed as api config`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -2581,7 +2581,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -2607,7 +2607,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addDependency(ConfigurationName.implementation, lib2)
 
       buildFile {
@@ -2664,7 +2664,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `deeply inherited from testImplementation dependency with auto-correct should be fixed as testImplementation`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -2675,7 +2675,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -2701,7 +2701,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addDependency(ConfigurationName.api, lib2)
 
       buildFile {
@@ -2727,7 +2727,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib4 = project(":lib4") {
+    val lib4 = kotlinProject(":lib4") {
       addDependency(ConfigurationName.testImplementation, lib3)
 
       buildFile {
@@ -2810,7 +2810,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited testFixtures and implementation from testFixtures with auto-correct should be fixed as testFixtures via testImplementation`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Interface.kt",
         """
@@ -2830,7 +2830,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       hasTestFixturesPlugin = true
       addDependency("testFixturesImplementation".asConfigurationName(), lib1)
       addDependency("testFixturesApi".asConfigurationName(), lib1, asTestFixture = true)
@@ -2861,7 +2861,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addDependency(ConfigurationName.testImplementation, lib2, asTestFixture = true)
 
       buildFile {
@@ -2938,7 +2938,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited testFixtures from testFixtures with auto-correct should be fixed as testFixtures via testImplementation`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -2950,7 +2950,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency("testFixturesApi".asConfigurationName(), lib1, asTestFixture = true)
 
       buildFile {
@@ -2977,7 +2977,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addDependency(ConfigurationName.testImplementation, lib2, asTestFixture = true)
 
       buildFile {
@@ -3045,7 +3045,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited testFixtures from api with auto-correct should be fixed as testFixtures via testImplementation`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       hasTestFixturesPlugin = true
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
@@ -3058,7 +3058,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       hasTestFixturesPlugin = true
       addDependency("api".asConfigurationName(), lib1, asTestFixture = true)
 
@@ -3086,7 +3086,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addDependency(ConfigurationName.testImplementation, lib2, asTestFixture = true)
 
       buildFile {
@@ -3169,7 +3169,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited main source should be added as non-test-fixtures testImplementation`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -3180,7 +3180,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency("testFixturesApi".asConfigurationName(), lib1)
 
       buildFile {
@@ -3207,7 +3207,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addDependency(ConfigurationName.testImplementation, lib2, asTestFixture = true)
 
       buildFile {
@@ -3265,7 +3265,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited main source testFixture in same module with auto-correct should be fixed as normal testImplementation`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       hasTestFixturesPlugin = true
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
@@ -3288,7 +3288,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.testImplementation, lib1, asTestFixture = true)
 
       buildFile {
@@ -3346,7 +3346,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `inherited main source testFixture in same module with auto-correct should be fixed as normal api`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -3368,7 +3368,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1, asTestFixture = true)
 
       buildFile {
@@ -3425,7 +3425,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `not inherited when only used in tests and already declared as testImplementation`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -3436,7 +3436,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.testImplementation, lib1)
 
       buildFile {
@@ -3481,7 +3481,7 @@ class InheritedDependenciesTest : RunnerTest() {
   @Test
   fun `not inherited when exposed as api but used in tests and already declared as testImplementation`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -3492,7 +3492,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -3518,7 +3518,7 @@ class InheritedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addDependency(ConfigurationName.testImplementation, lib1)
       addDependency(ConfigurationName.testImplementation, lib2)
 

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/MustBeApiTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/MustBeApiTest.kt
@@ -28,7 +28,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `public property from implementation without auto-correct should fail`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -39,7 +39,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -95,7 +95,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `public generic property from implementation without auto-correct should fail`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -106,7 +106,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -162,7 +162,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `public property from implementation with auto-correct should be fixed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -173,7 +173,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -228,7 +228,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `switching to api dependency after a blank line should preserve all newlines -- kotlin`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -239,7 +239,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
 
       buildFile {
         """
@@ -259,7 +259,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
 
       buildFile {
         """
@@ -279,7 +279,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib4 = project(":lib4") {
+    val lib4 = kotlinProject(":lib4") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib2)
       addDependency(ConfigurationName.implementation, lib3)
@@ -358,7 +358,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `switching to api dependency after a blank line should preserve all newlines -- groovy`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -369,7 +369,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
 
       buildFile {
         """
@@ -389,7 +389,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
 
       buildFile {
         """
@@ -409,7 +409,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib4 = project(":lib4") {
+    val lib4 = kotlinProject(":lib4") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib2)
       addDependency(ConfigurationName.implementation, lib3)
@@ -489,7 +489,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `private property from implementation with auto-correct should not be changed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -500,7 +500,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -545,7 +545,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `private property from implementation inside public class with auto-correct should not be changed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -556,7 +556,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -603,7 +603,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `internal property from implementation with auto-correct should not be changed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -614,7 +614,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -659,7 +659,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `public property from dependency in test source should not require API`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -670,7 +670,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.testImplementation, lib1)
 
       buildFile {
@@ -716,7 +716,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `internal property in class from implementation with auto-correct should not be changed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -727,7 +727,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -774,7 +774,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `supertype from implementation with auto-correct should be fixed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -785,7 +785,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -839,7 +839,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `must be api from invisible dependency with unrelated api dependency declaration`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -850,7 +850,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
 
       buildFile {
         """
@@ -870,7 +870,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       // lib1 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file
@@ -931,7 +931,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `must be api from invisible dependency with unrelated implementation dependency declaration`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -942,7 +942,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
 
       buildFile {
         """
@@ -962,7 +962,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       // lib1 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file
@@ -1023,7 +1023,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `must be api from invisible dependency with unrelated implementation external dependency`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1034,7 +1034,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       // lib1 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file
@@ -1094,7 +1094,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `must be api from invisible dependency with unrelated api external dependency`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1105,7 +1105,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       // lib1 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file
@@ -1165,7 +1165,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `must be api from invisible dependency with empty multi-line dependencies block`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1176,7 +1176,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       // lib1 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file
@@ -1234,7 +1234,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `must be api from invisible dependency with empty single-line dependencies block`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1245,7 +1245,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       // lib1 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file
@@ -1302,7 +1302,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `must be api from invisible dependency with no dependencies block`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1313,7 +1313,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       // lib1 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file
@@ -1368,7 +1368,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `auto-correct should only replace the configuration invocation text`() {
 
-    val lib1 = project(":implementation") {
+    val lib1 = kotlinProject(":implementation") {
       addSource(
         "com/modulecheck/implementation/Lib1Class.kt",
         """
@@ -1379,7 +1379,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -1437,7 +1437,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `supertype of internal class from implementation with auto-correct should not be changed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1448,7 +1448,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -1493,7 +1493,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `public return type from implementation with auto-correct should be fixed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1504,7 +1504,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -1558,7 +1558,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `internal return type from implementation with auto-correct should not be changed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1569,7 +1569,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -1614,7 +1614,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `public argument type from implementation with auto-correct should be fixed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1625,7 +1625,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -1679,7 +1679,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `public type argument from implementation with auto-correct should be fixed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1690,7 +1690,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -1744,7 +1744,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `public generic bound type from implementation with auto-correct should be fixed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1755,7 +1755,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -1809,7 +1809,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `public generic fully qualified bound type from implementation with auto-correct should be fixed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1820,7 +1820,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -1872,7 +1872,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `two public public properties from implementation with auto-correct should be fixed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1883,7 +1883,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addSource(
         "com/modulecheck/lib3/Lib3Class.kt",
         """
@@ -1894,7 +1894,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib3)
 
@@ -1959,7 +1959,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `two public supertypes from implementation with auto-correct should be fixed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1970,7 +1970,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addSource(
         "com/modulecheck/lib3/Lib3Class.kt",
         """
@@ -1981,7 +1981,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib3)
 
@@ -2045,7 +2045,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `two public return types from implementation with auto-correct should be fixed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -2056,7 +2056,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addSource(
         "com/modulecheck/lib3/Lib3Class.kt",
         """
@@ -2067,7 +2067,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib3)
 
@@ -2132,7 +2132,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `two public argument types from implementation with auto-correct should be fixed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -2143,7 +2143,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addSource(
         "com/modulecheck/lib3/Lib3Class.kt",
         """
@@ -2154,7 +2154,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib3)
 
@@ -2219,7 +2219,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `two public type arguments from implementation with auto-correct should be fixed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -2230,7 +2230,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addSource(
         "com/modulecheck/lib3/Lib3Class.kt",
         """
@@ -2241,7 +2241,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib3)
 
@@ -2305,7 +2305,7 @@ class MustBeApiTest : RunnerTest() {
   @Test
   fun `two public generic bound types from implementation with auto-correct should be fixed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -2316,7 +2316,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addSource(
         "com/modulecheck/lib3/Lib3Class.kt",
         """
@@ -2327,7 +2327,7 @@ class MustBeApiTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
       addDependency(ConfigurationName.implementation, lib3)
 

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/OverShotDependenciesTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/OverShotDependenciesTest.kt
@@ -27,7 +27,7 @@ class OverShotDependenciesTest : RunnerTest() {
   @Test
   fun `overshot as api but used in test without auto-correct should fail`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -38,7 +38,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -98,7 +98,7 @@ class OverShotDependenciesTest : RunnerTest() {
   @Test
   fun `overshot as implementation but used in debug without auto-correct should fail`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -109,7 +109,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -169,7 +169,7 @@ class OverShotDependenciesTest : RunnerTest() {
   @Test
   fun `overshot as api but used in test with auto-correct should be fixed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -180,7 +180,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -241,7 +241,7 @@ class OverShotDependenciesTest : RunnerTest() {
   @Test
   fun `overshot as implementation should be debugApi`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -252,7 +252,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = androidProject(":lib2", "com.modulecheck.lib2") {
+    val lib2 = androidLibrary(":lib2", "com.modulecheck.lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -313,7 +313,7 @@ class OverShotDependenciesTest : RunnerTest() {
   @Test
   fun `overshot as implementation should be debugImplementation`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -324,7 +324,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = androidProject(":lib2", "com.modulecheck.lib2") {
+    val lib2 = androidLibrary(":lib2", "com.modulecheck.lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -384,7 +384,7 @@ class OverShotDependenciesTest : RunnerTest() {
 
   @Test
   fun `overshot in non-android as implementation should be debugApi with quotes`() {
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -395,7 +395,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -456,7 +456,7 @@ class OverShotDependenciesTest : RunnerTest() {
   @Test
   fun `overshot as api but used in test with another testFixture with auto-correct should be fixed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -467,7 +467,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName("testFixturesApi"), lib1)
 
       addSource(
@@ -483,7 +483,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addDependency(ConfigurationName.api, lib1)
       addDependency(ConfigurationName.testImplementation, lib2, asTestFixture = true)
 
@@ -549,7 +549,7 @@ class OverShotDependenciesTest : RunnerTest() {
   @Test
   fun `overshot as api with config block and comment with auto-correct should be fixed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -560,7 +560,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       addSource(
@@ -575,7 +575,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addDependency(ConfigurationName.api, lib1)
       addDependency(ConfigurationName.testImplementation, lib2)
 
@@ -650,7 +650,7 @@ class OverShotDependenciesTest : RunnerTest() {
   @Test
   fun `overshot testFixture as api but used in test with another testFixture with auto-correct should be fixed`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -662,7 +662,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName("testFixturesApi"), lib1, asTestFixture = true)
 
       buildFile {
@@ -690,7 +690,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib3 = project(":lib3") {
+    val lib3 = kotlinProject(":lib3") {
       addDependency(ConfigurationName.api, lib1, asTestFixture = true)
       addDependency(ConfigurationName.testImplementation, lib2, asTestFixture = true)
 
@@ -766,7 +766,7 @@ class OverShotDependenciesTest : RunnerTest() {
   @Test
   fun `overshot as testImplementation from invisible dependency with a visible unrelated api project dependency`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -777,7 +777,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       // lib1 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file
@@ -841,7 +841,7 @@ class OverShotDependenciesTest : RunnerTest() {
   @Test
   fun `overshot as testImplementation from invisible dependency with a visible unrelated implementation project dependency`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -852,7 +852,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       // lib1 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file
@@ -916,7 +916,7 @@ class OverShotDependenciesTest : RunnerTest() {
   @Test
   fun `overshot as testImplementation from invisible dependency with an empty multi-line dependencies block`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -927,7 +927,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       // lib1 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file
@@ -989,7 +989,7 @@ class OverShotDependenciesTest : RunnerTest() {
   @Test
   fun `overshot as testImplementation from invisible dependency with an empty single-line dependencies block`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1000,7 +1000,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       // lib1 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file
@@ -1061,7 +1061,7 @@ class OverShotDependenciesTest : RunnerTest() {
   @Test
   fun `overshot as testImplementation from invisible dependency with no dependencies block`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1072,7 +1072,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       // lib1 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file
@@ -1131,7 +1131,7 @@ class OverShotDependenciesTest : RunnerTest() {
   @Test
   fun `overshot as testImplementation from invisible dependency with only external implementation dependency`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1142,7 +1142,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       // lib1 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file
@@ -1206,7 +1206,7 @@ class OverShotDependenciesTest : RunnerTest() {
   @Test
   fun `overshot as implementation from invisible dependency with only external api dependency`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1217,7 +1217,7 @@ class OverShotDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       // lib1 is added as a dependency, but it's not in the build file.
       // This is intentional, because it mimics the behavior of a convention plugin
       // which adds a dependency without any visible declaration in the build file

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/SortDependenciesTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/SortDependenciesTest.kt
@@ -32,7 +32,7 @@ class SortDependenciesTest : RunnerTest() {
   @Test
   fun `kts out-of-order dependencies should be sorted`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       buildFile {
         """
       plugins {
@@ -97,7 +97,7 @@ class SortDependenciesTest : RunnerTest() {
   @Test
   fun `kts multi-line comments should move with their declarations`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       buildFile {
         """
       plugins {
@@ -142,7 +142,7 @@ class SortDependenciesTest : RunnerTest() {
   @Test
   fun `kts multi-line kdoc comments should move with their declarations`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       buildFile {
         """
       plugins {
@@ -187,7 +187,7 @@ class SortDependenciesTest : RunnerTest() {
   @Test
   fun `kts preceding comments should move with their declarations`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       buildFile {
         """
       plugins {
@@ -228,7 +228,7 @@ class SortDependenciesTest : RunnerTest() {
   @Test
   fun `kts trailing comments should move with their declarations`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       buildFile {
         """
       plugins {
@@ -267,7 +267,7 @@ class SortDependenciesTest : RunnerTest() {
   @Test
   fun `kts sorting should be idempotent`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       buildFile {
         """
       plugins {
@@ -367,7 +367,7 @@ class SortDependenciesTest : RunnerTest() {
   @Test
   fun `groovy out-of-order plugins should be sorted`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       buildFile.delete()
       buildFile = File(projectDir, "build.gradle")
       buildFile.writeGroovy(
@@ -436,7 +436,7 @@ class SortDependenciesTest : RunnerTest() {
   @Test
   fun `groovy multi-line comments should move with declarations`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       buildFile.delete()
       buildFile = File(projectDir, "build.gradle")
       buildFile.writeGroovy(
@@ -483,7 +483,7 @@ class SortDependenciesTest : RunnerTest() {
   @Test
   fun `groovy multi-line javadoc comments should move with declarations`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       buildFile.delete()
       buildFile = File(projectDir, "build.gradle")
       buildFile.writeGroovy(
@@ -530,7 +530,7 @@ class SortDependenciesTest : RunnerTest() {
   @Test
   fun `groovy preceding comments should move with declarations`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       buildFile.delete()
       buildFile = File(projectDir, "build.gradle")
       buildFile.writeGroovy(
@@ -573,7 +573,7 @@ class SortDependenciesTest : RunnerTest() {
   @Test
   fun `groovy trailing comments should move with declarations`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       buildFile.delete()
       buildFile = File(projectDir, "build.gradle")
       buildFile.writeGroovy(
@@ -614,7 +614,7 @@ class SortDependenciesTest : RunnerTest() {
   @Test
   fun `groovy sorting should be idempotent`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       buildFile.delete()
       buildFile = File(projectDir, "build.gradle")
       buildFile.writeGroovy(

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/SortPluginsTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/SortPluginsTest.kt
@@ -30,7 +30,7 @@ class SortPluginsTest : RunnerTest() {
   @Test
   fun `kts out-of-order plugins should be sorted`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       buildFile {
         """
       plugins {
@@ -60,7 +60,7 @@ class SortPluginsTest : RunnerTest() {
   @Test
   fun `kts sorting should be idempotent`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       buildFile {
         """
       plugins {
@@ -103,7 +103,7 @@ class SortPluginsTest : RunnerTest() {
   @Test
   fun `groovy out-of-order plugins should be sorted`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       buildFile.delete()
       buildFile = File(projectDir, "build.gradle")
       buildFile.writeGroovy(
@@ -135,7 +135,7 @@ class SortPluginsTest : RunnerTest() {
   @Test
   fun `groovy sorting should be idempotent`() {
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       buildFile.delete()
       buildFile = File(projectDir, "build.gradle")
       buildFile.writeGroovy(

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/TextReportingTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/TextReportingTest.kt
@@ -44,7 +44,7 @@ internal class TextReportingTest : RunnerTest() {
       findingFactory = findingFactory(
         listOf(
           CouldUseAnvilFinding(
-            dependentProject = project(":lib1"),
+            dependentProject = kotlinProject(":lib1"),
             buildFile = testProjectDir
           )
         )
@@ -81,7 +81,7 @@ internal class TextReportingTest : RunnerTest() {
       findingFactory = findingFactory(
         listOf(
           CouldUseAnvilFinding(
-            dependentProject = project(":lib1"),
+            dependentProject = kotlinProject(":lib1"),
             buildFile = testProjectDir
           )
         )

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/UnusedDependenciesTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/UnusedDependenciesTest.kt
@@ -29,9 +29,9 @@ class UnusedDependenciesTest : RunnerTest() {
   @Test
   fun `unused without auto-correct should fail`() {
 
-    val lib1 = project(":lib1")
+    val lib1 = kotlinProject(":lib1")
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -74,9 +74,9 @@ class UnusedDependenciesTest : RunnerTest() {
   @Test
   fun `unused with auto-correct should be commented out`() {
 
-    val lib1 = project(":lib1")
+    val lib1 = kotlinProject(":lib1")
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -121,9 +121,9 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = true
 
-    val lib1 = project(":lib1")
+    val lib1 = kotlinProject(":lib1")
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -167,9 +167,9 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = true
 
-    val lib1 = project(":lib1")
+    val lib1 = kotlinProject(":lib1")
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -207,9 +207,9 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = true
 
-    val lib1 = project(":lib1")
+    val lib1 = kotlinProject(":lib1")
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -247,9 +247,9 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = true
 
-    val lib1 = project(":lib1")
+    val lib1 = kotlinProject(":lib1")
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -295,9 +295,9 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = true
 
-    val lib1 = project(":lib1")
+    val lib1 = kotlinProject(":lib1")
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -341,9 +341,9 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = true
 
-    val lib1 = project(":lib1")
+    val lib1 = kotlinProject(":lib1")
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -390,9 +390,9 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = true
 
-    val lib1 = project(":lib1")
+    val lib1 = kotlinProject(":lib1")
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -440,9 +440,9 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = false
 
-    val lib1 = project(":lib1")
+    val lib1 = kotlinProject(":lib1")
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -491,9 +491,9 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = false
 
-    val lib1 = project(":lib1")
+    val lib1 = kotlinProject(":lib1")
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile {
@@ -544,7 +544,7 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = false
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -557,7 +557,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile.writeText(
@@ -608,7 +608,7 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = false
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -621,7 +621,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile.writeText(
@@ -676,7 +676,7 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = false
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -689,7 +689,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile.writeText(
@@ -743,7 +743,7 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = false
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -756,7 +756,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.implementation, lib1)
 
       buildFile.writeText(
@@ -809,7 +809,7 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = false
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -820,7 +820,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.testImplementation, lib1)
 
       buildFile {
@@ -868,7 +868,7 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = false
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -879,7 +879,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = androidProject(":lib2", "com.modulecheck.lib2") {
+    val lib2 = androidLibrary(":lib2", "com.modulecheck.lib2") {
       addDependency(ConfigurationName.androidTestImplementation, lib1)
 
       buildFile {
@@ -929,7 +929,7 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = false
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1View.kt",
         """
@@ -940,7 +940,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = androidProject(":lib2", "com.modulecheck.lib2") {
+    val lib2 = androidLibrary(":lib2", "com.modulecheck.lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -997,7 +997,7 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = false
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       platformPlugin.viewBindingEnabled = true
 
       addLayoutFile(
@@ -1008,7 +1008,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = androidProject(":lib2", "com.modulecheck.lib2") {
+    val lib2 = androidLibrary(":lib2", "com.modulecheck.lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -1058,7 +1058,7 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = false
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1069,7 +1069,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -1116,7 +1116,7 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = false
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1128,7 +1128,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.testImplementation, lib1, asTestFixture = true)
 
       buildFile {
@@ -1176,7 +1176,7 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = false
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1188,7 +1188,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.testImplementation, lib1, asTestFixture = true)
 
       buildFile {
@@ -1233,7 +1233,7 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = false
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1254,7 +1254,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.testImplementation, lib1, asTestFixture = true)
 
       buildFile {
@@ -1317,7 +1317,7 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = false
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1332,7 +1332,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -1379,7 +1379,7 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = false
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
 
       addResourceFile(
         "values/strings.xml",
@@ -1391,7 +1391,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = androidProject(":lib2", "com.modulecheck.lib2") {
+    val lib2 = androidLibrary(":lib2", "com.modulecheck.lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -1438,7 +1438,7 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = false
 
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
 
       addResourceFile(
         "values/strings.xml",
@@ -1450,7 +1450,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = androidProject(":lib2", "com.modulecheck.lib2") {
+    val lib2 = androidLibrary(":lib2", "com.modulecheck.lib2") {
       addDependency(ConfigurationName.api, lib1)
 
       buildFile {
@@ -1508,7 +1508,7 @@ class UnusedDependenciesTest : RunnerTest() {
 
     settings.deleteUnused = false
 
-    val lib1 = project(":lib1") {
+    val lib1 = kotlinProject(":lib1") {
       addSource(
         "com/modulecheck/lib1/Lib1Class.kt",
         """
@@ -1519,7 +1519,7 @@ class UnusedDependenciesTest : RunnerTest() {
       )
     }
 
-    val lib2 = project(":lib2") {
+    val lib2 = kotlinProject(":lib2") {
       addDependency(ConfigurationName.api, lib1)
       anvilGradlePlugin = AnvilGradlePlugin(SemVer(2, 3, 8), true)
 

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/UnusedKaptProcessorTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/UnusedKaptProcessorTest.kt
@@ -30,7 +30,7 @@ class UnusedKaptProcessorTest : RunnerTest() {
   @Test
   fun `unused from kapt configuration without autoCorrect should fail`() {
 
-    val app = project(":app") {
+    val app = kotlinProject(":app") {
       hasKapt = true
 
       addExternalDependency(ConfigurationName.kapt, dagger)
@@ -84,7 +84,7 @@ class UnusedKaptProcessorTest : RunnerTest() {
   @Test
   fun `unused from non-kapt configuration without autoCorrect should pass without changes`() {
 
-    val app = project(":app") {
+    val app = kotlinProject(":app") {
       hasKapt = true
 
       addExternalDependency(ConfigurationName.api, dagger)
@@ -124,7 +124,7 @@ class UnusedKaptProcessorTest : RunnerTest() {
   @Test
   fun `used in main with main kapt should pass without changes`() {
 
-    val app = project(":app") {
+    val app = kotlinProject(":app") {
       hasKapt = true
 
       addExternalDependency(ConfigurationName.kapt, dagger)
@@ -174,7 +174,7 @@ class UnusedKaptProcessorTest : RunnerTest() {
   @Test
   fun `used in test with test kapt should pass without changes`() {
 
-    val app = project(":app") {
+    val app = kotlinProject(":app") {
       hasKapt = true
 
       addExternalDependency("kaptTest".asConfigurationName(), dagger)
@@ -225,7 +225,7 @@ class UnusedKaptProcessorTest : RunnerTest() {
   @Test
   fun `unused with main kapt with autoCorrect and no other processors should remove processor and plugin`() {
 
-    val app = project(":app") {
+    val app = kotlinProject(":app") {
       hasKapt = true
 
       addExternalDependency(ConfigurationName.kapt, dagger)

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/UnusedKotlinAndroidExtensionsTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/UnusedKotlinAndroidExtensionsTest.kt
@@ -38,7 +38,7 @@ class UnusedKotlinAndroidExtensionsTest : RunnerTest() {
   fun `unused KotlinAndroidExtensions should pass if check is disabled`() {
     settings.checks.unusedKotlinAndroidExtensions = false
 
-    androidProject(":lib1", "com.modulecheck.lib1") {
+    androidLibrary(":lib1", "com.modulecheck.lib1") {
       writeBuildFileWithPlugin()
       addAnyLayoutFile()
     }
@@ -49,7 +49,7 @@ class UnusedKotlinAndroidExtensionsTest : RunnerTest() {
 
   @Test
   fun `unused KotlinAndroidExtensions without auto-correct should fail`() {
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       writeBuildFileWithPlugin()
       addAnyLayoutFile()
     }
@@ -71,7 +71,7 @@ class UnusedKotlinAndroidExtensionsTest : RunnerTest() {
 
   @Test
   fun `used KotlinAndroidExtensions synthetics should pass and should not be corrected`() {
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       writeBuildFileWithPlugin()
       addAnyLayoutFile()
       addSource(
@@ -109,7 +109,7 @@ class UnusedKotlinAndroidExtensionsTest : RunnerTest() {
 
   @Test
   fun `used KotlinAndroidExtensions parcelize should pass and should not be corrected`() {
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       writeBuildFileWithPlugin()
       addSource(
         "com/modulecheck/lib1/Source.kt",
@@ -140,7 +140,7 @@ class UnusedKotlinAndroidExtensionsTest : RunnerTest() {
 
   @Test
   fun `unused KotlinAndroidExtensions should be fixed`() {
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       writeBuildFileWithPlugin()
     }
 
@@ -161,7 +161,7 @@ class UnusedKotlinAndroidExtensionsTest : RunnerTest() {
 
   @Test
   fun `unused KotlinAndroidExtensions from id should be fixed`() {
-    val lib1 = androidProject(":lib1", "com.modulecheck.lib1") {
+    val lib1 = androidLibrary(":lib1", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {

--- a/modulecheck-plugin/src/test/kotlin/modulecheck/gradle/AndroidBuildConfigAvoidanceTest.kt
+++ b/modulecheck-plugin/src/test/kotlin/modulecheck/gradle/AndroidBuildConfigAvoidanceTest.kt
@@ -25,7 +25,7 @@ class AndroidBuildConfigAvoidanceTest : BasePluginTest() {
 
   @Test
   fun `buildConfig task should be required when not configured in android library module`() {
-    androidProject(":", "com.modulecheck.lib1") {
+    androidLibrary(":", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -75,7 +75,7 @@ class AndroidBuildConfigAvoidanceTest : BasePluginTest() {
 
   @Test
   fun `buildConfig task should not be required when disabled in android library module`() {
-    androidProject(":", "com.modulecheck.lib1") {
+    androidLibrary(":", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -114,7 +114,7 @@ class AndroidBuildConfigAvoidanceTest : BasePluginTest() {
 
   @Test
   fun `buildConfig task should not be required when disabled in android dynamic-feature module`() {
-    androidProject(":", "com.modulecheck.lib1") {
+    androidLibrary(":", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -152,7 +152,7 @@ class AndroidBuildConfigAvoidanceTest : BasePluginTest() {
 
   @Test
   fun `buildConfig task should not be required when disabled in android test module`() {
-    androidProject(":", "com.modulecheck.lib1") {
+    androidLibrary(":", "com.modulecheck.lib1") {
       buildFile {
         """
         plugins {
@@ -194,7 +194,7 @@ class AndroidBuildConfigAvoidanceTest : BasePluginTest() {
       )
     }
 
-    androidProject(":app", "com.modulecheck.app") {
+    androidLibrary(":app", "com.modulecheck.app") {
       buildFile {
         """
         plugins {

--- a/modulecheck-plugin/src/test/kotlin/modulecheck/gradle/AnvilScopesTest.kt
+++ b/modulecheck-plugin/src/test/kotlin/modulecheck/gradle/AnvilScopesTest.kt
@@ -104,7 +104,7 @@ class AnvilScopesTest : BasePluginTest() {
         }
       )
     }
-    ProjectSpec("project") {
+    ProjectSpec("kotlinProject") {
       applyEach(projects) { project ->
         addSubproject(project)
       }
@@ -170,7 +170,7 @@ class AnvilScopesTest : BasePluginTest() {
         }
       )
     }
-    ProjectSpec("project") {
+    ProjectSpec("kotlinProject") {
       applyEach(projects) { project ->
         addSubproject(project)
       }
@@ -244,7 +244,7 @@ class AnvilScopesTest : BasePluginTest() {
         }
       )
     }
-    ProjectSpec("project") {
+    ProjectSpec("kotlinProject") {
       applyEach(projects) { project ->
         addSubproject(project)
       }
@@ -317,7 +317,7 @@ class AnvilScopesTest : BasePluginTest() {
         }
       )
     }
-    ProjectSpec("project") {
+    ProjectSpec("kotlinProject") {
       applyEach(projects) { project ->
         addSubproject(project)
       }
@@ -387,7 +387,7 @@ class AnvilScopesTest : BasePluginTest() {
         }
       )
     }
-    ProjectSpec("project") {
+    ProjectSpec("kotlinProject") {
       applyEach(projects) { project ->
         addSubproject(project)
       }

--- a/modulecheck-plugin/src/test/kotlin/modulecheck/gradle/ConfigValidationTest.kt
+++ b/modulecheck-plugin/src/test/kotlin/modulecheck/gradle/ConfigValidationTest.kt
@@ -64,7 +64,7 @@ class ConfigValidationTest : BasePluginTest() {
 
   @Test
   fun `Kotlin configuration`() {
-    project(":") {
+    kotlinProject(":") {
       buildFile.writeKotlin(
         """
         plugins {
@@ -147,7 +147,7 @@ class ConfigValidationTest : BasePluginTest() {
 
   @Test
   fun `Groovy configuration`() {
-    project(":") {
+    kotlinProject(":") {
       buildFile.delete()
       buildFile = projectDir.child("build.gradle")
       buildFile.writeGroovy(

--- a/modulecheck-plugin/src/test/kotlin/modulecheck/gradle/DepthReportTaskTest.kt
+++ b/modulecheck-plugin/src/test/kotlin/modulecheck/gradle/DepthReportTaskTest.kt
@@ -25,7 +25,7 @@ internal class DepthReportTaskTest : BasePluginTest() {
   @Test
   fun `depth report should be created if depth task is invoked with default settings`() {
 
-    val root = project(":") {
+    val root = kotlinProject(":") {
 
       buildFile {
         """
@@ -65,7 +65,7 @@ internal class DepthReportTaskTest : BasePluginTest() {
           """.trimIndent()
         )
 
-      project(":lib1") {
+      kotlinProject(":lib1") {
         buildFile {
           """
           plugins {
@@ -75,7 +75,7 @@ internal class DepthReportTaskTest : BasePluginTest() {
         }
       }
 
-      project(":lib2") {
+      kotlinProject(":lib2") {
         buildFile {
           """
           plugins {
@@ -88,7 +88,7 @@ internal class DepthReportTaskTest : BasePluginTest() {
         }
       }
 
-      project(":app") {
+      kotlinProject(":app") {
         buildFile {
           """
           plugins {

--- a/modulecheck-plugin/src/test/kotlin/modulecheck/gradle/GraphReportTaskTest.kt
+++ b/modulecheck-plugin/src/test/kotlin/modulecheck/gradle/GraphReportTaskTest.kt
@@ -25,7 +25,7 @@ internal class GraphReportTaskTest : BasePluginTest() {
   @Test
   fun `graphs report should be created if graph task is invoked with default settings`() {
 
-    val root = project(":") {
+    val root = kotlinProject(":") {
 
       buildFile {
         """
@@ -65,7 +65,7 @@ internal class GraphReportTaskTest : BasePluginTest() {
           """.trimIndent()
         )
 
-      project(":lib1") {
+      kotlinProject(":lib1") {
         buildFile {
           """
           plugins {
@@ -75,7 +75,7 @@ internal class GraphReportTaskTest : BasePluginTest() {
         }
       }
 
-      project(":lib2") {
+      kotlinProject(":lib2") {
         buildFile {
           """
           plugins {
@@ -88,7 +88,7 @@ internal class GraphReportTaskTest : BasePluginTest() {
         }
       }
 
-      project(":app") {
+      kotlinProject(":app") {
         buildFile {
           """
           plugins {

--- a/modulecheck-plugin/src/test/kotlin/modulecheck/gradle/TasksValidationTest.kt
+++ b/modulecheck-plugin/src/test/kotlin/modulecheck/gradle/TasksValidationTest.kt
@@ -24,7 +24,7 @@ class TasksValidationTest : BasePluginTest() {
 
   @Test
   fun `all tasks with descriptions`() {
-    project(":") {
+    kotlinProject(":") {
       buildFile.writeKotlin(
         """
         plugins {

--- a/modulecheck-plugin/src/test/kotlin/modulecheck/gradle/UnusedDependenciesPluginTest.kt
+++ b/modulecheck-plugin/src/test/kotlin/modulecheck/gradle/UnusedDependenciesPluginTest.kt
@@ -84,7 +84,7 @@ class UnusedDependenciesPluginTest : BasePluginTest() {
       )
     }
 
-    ProjectSpec("project") {
+    ProjectSpec("kotlinProject") {
       applyEach(projects) { project ->
         addSubproject(project)
       }
@@ -196,7 +196,7 @@ class UnusedDependenciesPluginTest : BasePluginTest() {
           // https://github.com/GradleUp/auto-manifest
           // For some reason, that plugin doesn't work with Gradle TestKit.  Its task is never
           // registered, and the manifest location is never changed from the default.  When I open
-          // the generated project dir and execute the task from terminal, it works fine...
+          // the generated kotlinProject dir and execute the task from terminal, it works fine...
           // This does the same thing, but uses a different default directory.
           addBlock(
             """
@@ -237,7 +237,7 @@ class UnusedDependenciesPluginTest : BasePluginTest() {
       )
     }
 
-    ProjectSpec("project") {
+    ProjectSpec("kotlinProject") {
       addSubproject(appProject)
       addSubproject(androidSub1)
       addSettingsSpec(projectSettings.build())
@@ -311,7 +311,7 @@ class UnusedDependenciesPluginTest : BasePluginTest() {
       )
     }
 
-    ProjectSpec("project") {
+    ProjectSpec("kotlinProject") {
       addSubproject(androidSub1)
       addSubproject(androidSub2)
       addSettingsSpec(projectSettings.build())

--- a/modulecheck-project/api/src/testFixtures/kotlin/modulecheck/project/test/ProjectTest.kt
+++ b/modulecheck-project/api/src/testFixtures/kotlin/modulecheck/project/test/ProjectTest.kt
@@ -143,15 +143,6 @@ abstract class ProjectTest : BaseTest() {
       .toRealMcProject()
   }
 
-  @Deprecated(
-    "use `kotlinProject`",
-    ReplaceWith("kotlinProject(path, config)")
-  )
-  fun project(
-    path: String,
-    config: McProjectBuilder<KotlinJvmPluginBuilder>.() -> Unit = {}
-  ): McProject = kotlinProject(path, config)
-
   fun kotlinProject(
     path: String,
     config: McProjectBuilder<KotlinJvmPluginBuilder>.() -> Unit = {}
@@ -184,16 +175,6 @@ abstract class ProjectTest : BaseTest() {
       config = config
     )
   }
-
-  @Deprecated(
-    "use `androidLibrary`",
-    ReplaceWith("androidLibrary(path, androidPackage, config)")
-  )
-  fun androidProject(
-    path: String,
-    androidPackage: String,
-    config: McProjectBuilder<AndroidLibraryPluginBuilder>.() -> Unit = {}
-  ): McProject = androidLibrary(path, androidPackage, config)
 
   fun androidLibrary(
     path: String,
@@ -259,7 +240,7 @@ abstract class ProjectTest : BaseTest() {
   fun simpleProject(
     buildFileText: String? = null,
     path: String = ":lib"
-  ) = project(path) {
+  ) = this.kotlinProject(path) {
 
     if (buildFileText != null) {
       buildFile.writeText(buildFileText)
@@ -268,9 +249,9 @@ abstract class ProjectTest : BaseTest() {
     addSource(
       "com/lib1/Lib1Class.kt",
       """
-        package com.lib1
+      package com.lib1
 
-        class Lib1Class
+      class Lib1Class
       """,
       SourceSetName.MAIN
     )
@@ -316,7 +297,7 @@ abstract class ProjectTest : BaseTest() {
             if (unresolved) {
               fail(
                 """
-                |Project ${project.path} has a reference which must be declared in a dependency project.
+                |Project ${project.path} has a reference which must be declared in a dependency kotlinProject.
                 |
                 |-- reference:
                 |   $referenceName


### PR DESCRIPTION
I deprecated these functions as part of #474, but held off on replacing them just to avoid the extra diff.