### PR TITLE
Support the alternative usage of kapt plugin

### DIFF
--- a/modulecheck-core/src/main/kotlin/modulecheck/core/UnusedPluginFinding.kt
+++ b/modulecheck-core/src/main/kotlin/modulecheck/core/UnusedPluginFinding.kt
@@ -35,6 +35,7 @@ data class UnusedPluginFinding(
   override val buildFile: File,
   override val findingName: String,
   val pluginId: String,
+  val alternatePluginId: String = "",
   val kotlinPluginFunction: String = ""
 ) : Finding, Problem, Fixable, Deletable {
 
@@ -53,8 +54,10 @@ data class UnusedPluginFinding(
     val row = lines
       .indexOfFirst { line ->
         line.contains("id(\"$pluginId\")") ||
+        line.contains("id(\"$alternatePluginId\")") ||
           line.contains(kotlinPluginFunction) ||
-          line.contains("plugin = \"$pluginId\")")
+          line.contains("plugin = \"$pluginId\")") ||
+          line.contains("plugin = \"$alternatePluginId\")")
       }
 
     if (row < 0) return@lazyDeferred null
@@ -71,6 +74,9 @@ data class UnusedPluginFinding(
       "id(\"$pluginId\")",
       "id \"$pluginId\"",
       "id '$pluginId'",
+      "id(\"$alternatePluginId\")",
+      "id \"$alternatePluginId\"",
+      "id '$alternatePluginId'",
       kotlinPluginFunction
     ).firstNotNullOfOrNull { id ->
       dependentProject.buildFileParser.pluginsBlock()?.getById(id)

--- a/modulecheck-core/src/main/kotlin/modulecheck/core/rule/UnusedKaptRule.kt
+++ b/modulecheck-core/src/main/kotlin/modulecheck/core/rule/UnusedKaptRule.kt
@@ -32,6 +32,7 @@ import modulecheck.utils.LazySet
 import modulecheck.utils.any
 
 const val KAPT_PLUGIN_ID = "org.jetbrains.kotlin.kapt"
+const val KAPT_ALTERNATE_PLUGIN_ID = "kotlin-kapt"
 private const val KAPT_PLUGIN_FUN = "kotlin(\"kapt\")"
 
 class UnusedKaptRule(
@@ -91,6 +92,7 @@ class UnusedKaptRule(
             buildFile = project.buildFile,
             findingName = "unusedKaptPlugin",
             pluginId = KAPT_PLUGIN_ID,
+            alternatePluginId = KAPT_ALTERNATE_PLUGIN_ID,
             kotlinPluginFunction = KAPT_PLUGIN_FUN
           )
         } else {


### PR DESCRIPTION
In our project, the line numbers were not shown correctly. I figured out we had another was of adding kapt plugin.

Btw, `@Suppress` annotation also did not work for Kapt but I didn't have a chance to reproduce that. I'm hoping that this also fixes that issue.