### PR TITLE
Fix execution optimization for KtLint in `:modulecheck-plugin`

### DIFF
--- a/modulecheck-plugin/build.gradle.kts
+++ b/modulecheck-plugin/build.gradle.kts
@@ -106,7 +106,7 @@ sourceSets {
   }
 }
 
-val generateBuildProperties by tasks.registering {
+val generateBuildProperties by tasks.registering generator@{
 
   val version = modulecheck.builds.VERSION_NAME
   val sourceWebsite = modulecheck.builds.SOURCE_WEBSITE
@@ -136,8 +136,12 @@ val generateBuildProperties by tasks.registering {
   }
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>()
-  .configureEach {
-
-    dependsOn(generateBuildProperties)
-  }
+tasks.named("runKtlintCheckOverMainSourceSet").configure {
+  dependsOn(generateBuildProperties)
+}
+tasks.named("runKtlintFormatOverMainSourceSet").configure {
+  dependsOn(generateBuildProperties)
+}
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+  dependsOn(generateBuildProperties)
+}


### PR DESCRIPTION
```
Execution optimizations have been disabled for task ':modulecheck-plugin:runKtlintCheckOverMainSourceSet' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/Users/rbusarow/projects/ModuleCheck/modulecheck-plugin/build/generated/sources/buildProperties/kotlin/main'. Reason: Task ':modulecheck-plugin:runKtlintCheckOverMainSourceSet' uses this output of task ':modulecheck-plugin:generateBuildProperties' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.4.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```