### PR TITLE
rename `modulecheck.reporting.logging.Logger` to `McLogger`

### DIFF
--- a/modulecheck-api/src/testFixtures/kotlin/modulecheck/api/test/ReportingLogger.kt
+++ b/modulecheck-api/src/testFixtures/kotlin/modulecheck/api/test/ReportingLogger.kt
@@ -15,7 +15,7 @@
 
 package modulecheck.api.test
 
-import modulecheck.reporting.logging.Logger
+import modulecheck.reporting.logging.McLogger
 import modulecheck.reporting.logging.Report
 import modulecheck.reporting.logging.Report.ReportEntry
 import modulecheck.reporting.logging.Report.ReportEntry.AppendNewLine
@@ -32,7 +32,7 @@ import modulecheck.reporting.logging.Report.ReportEntry.WarningLine
 
 class ReportingLogger(
   private val mirrorToStandardOut: Boolean = true
-) : Logger {
+) : McLogger {
 
   private val entries = mutableListOf<ReportEntry>()
 

--- a/modulecheck-parsing/gradle/src/main/kotlin/modulecheck/parsing/gradle/DependenciesBlock.kt
+++ b/modulecheck-parsing/gradle/src/main/kotlin/modulecheck/parsing/gradle/DependenciesBlock.kt
@@ -17,11 +17,11 @@ package modulecheck.parsing.gradle
 
 import modulecheck.parsing.gradle.DependencyDeclaration.ConfigurationNameTransform
 import modulecheck.parsing.gradle.ProjectPath.StringProjectPath
-import modulecheck.reporting.logging.Logger
+import modulecheck.reporting.logging.McLogger
 import modulecheck.utils.remove
 
 abstract class DependenciesBlock(
-  private val logger: Logger,
+  private val logger: McLogger,
   suppressAll: List<String>,
   private val configurationNameTransform: ConfigurationNameTransform
 ) : Block<DependencyDeclaration> {
@@ -239,7 +239,7 @@ abstract class DependenciesBlock(
     val testFixturesRegex = "testFixtures\\([\\s\\S]*\\)".toRegex()
 
     @Deprecated("This will be removed soon.")
-    private fun migrateLegacyIdOrNull(legacyID: String, logger: Logger): String? {
+    private fun migrateLegacyIdOrNull(legacyID: String, logger: McLogger): String? {
 
       val migrated = when (legacyID) {
         "useAnvilFactories" -> "use-anvil-factory-generation"

--- a/modulecheck-parsing/groovy-antlr/src/main/kotlin/modulecheck/parsing/groovy/antlr/GroovyDependenciesBlock.kt
+++ b/modulecheck-parsing/groovy-antlr/src/main/kotlin/modulecheck/parsing/groovy/antlr/GroovyDependenciesBlock.kt
@@ -16,10 +16,10 @@
 package modulecheck.parsing.groovy.antlr
 
 import modulecheck.parsing.gradle.DependenciesBlock
-import modulecheck.reporting.logging.Logger
+import modulecheck.reporting.logging.McLogger
 
 class GroovyDependenciesBlock(
-  logger: Logger,
+  logger: McLogger,
   override val fullText: String,
   override val lambdaContent: String,
   suppressAll: List<String>

--- a/modulecheck-parsing/groovy-antlr/src/main/kotlin/modulecheck/parsing/groovy/antlr/GroovyDependencyBlockParser.kt
+++ b/modulecheck-parsing/groovy-antlr/src/main/kotlin/modulecheck/parsing/groovy/antlr/GroovyDependencyBlockParser.kt
@@ -22,7 +22,7 @@ import modulecheck.parsing.gradle.MavenCoordinates
 import modulecheck.parsing.gradle.ProjectAccessor
 import modulecheck.parsing.gradle.ProjectPath
 import modulecheck.parsing.gradle.asConfigurationName
-import modulecheck.reporting.logging.Logger
+import modulecheck.reporting.logging.McLogger
 import org.apache.groovy.parser.antlr4.GroovyParser.BlockStatementContext
 import org.apache.groovy.parser.antlr4.GroovyParser.ClosureContext
 import org.apache.groovy.parser.antlr4.GroovyParser.ExpressionListElementContext
@@ -35,7 +35,7 @@ import java.io.File
 import javax.inject.Inject
 
 class GroovyDependencyBlockParser @Inject constructor(
-  private val logger: Logger
+  private val logger: McLogger
 ) {
 
   fun parse(file: File): List<GroovyDependenciesBlock> = parse(file) {

--- a/modulecheck-parsing/psi/src/main/kotlin/modulecheck/parsing/psi/KotlinDependenciesBlock.kt
+++ b/modulecheck-parsing/psi/src/main/kotlin/modulecheck/parsing/psi/KotlinDependenciesBlock.kt
@@ -17,10 +17,10 @@ package modulecheck.parsing.psi
 
 import modulecheck.parsing.gradle.DependenciesBlock
 import modulecheck.parsing.gradle.DependencyDeclaration.ConfigurationNameTransform
-import modulecheck.reporting.logging.Logger
+import modulecheck.reporting.logging.McLogger
 
 class KotlinDependenciesBlock(
-  logger: Logger,
+  logger: McLogger,
   override val fullText: String,
   override val lambdaContent: String,
   suppressAll: List<String>,

--- a/modulecheck-parsing/psi/src/main/kotlin/modulecheck/parsing/psi/KotlinDependencyBlockParser.kt
+++ b/modulecheck-parsing/psi/src/main/kotlin/modulecheck/parsing/psi/KotlinDependencyBlockParser.kt
@@ -24,7 +24,7 @@ import modulecheck.parsing.gradle.buildFileInvocationText
 import modulecheck.parsing.psi.internal.asKtFile
 import modulecheck.parsing.psi.internal.getChildrenOfTypeRecursive
 import modulecheck.parsing.psi.internal.nameSafe
-import modulecheck.reporting.logging.Logger
+import modulecheck.reporting.logging.McLogger
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.psi.KtAnnotatedExpression
 import org.jetbrains.kotlin.psi.KtBlockExpression
@@ -38,7 +38,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getChildOfType
 import javax.inject.Inject
 
 class KotlinDependencyBlockParser @Inject constructor(
-  private val logger: Logger
+  private val logger: McLogger
 ) {
 
   @Suppress("ReturnCount")

--- a/modulecheck-plugin/src/main/kotlin/modulecheck/gradle/GradleProjectProvider.kt
+++ b/modulecheck-plugin/src/main/kotlin/modulecheck/gradle/GradleProjectProvider.kt
@@ -23,7 +23,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import modulecheck.config.ModuleCheckSettings
 import modulecheck.core.rule.KAPT_PLUGIN_ID
-import modulecheck.gradle.task.GradleLogger
+import modulecheck.gradle.task.GradleMcLogger
 import modulecheck.parsing.gradle.BuildFileParser
 import modulecheck.parsing.gradle.ProjectPath.StringProjectPath
 import modulecheck.parsing.gradle.asConfigurationName
@@ -50,7 +50,7 @@ class GradleProjectProvider @AssistedInject constructor(
   private val rootGradleProject: GradleProject,
   private val settings: ModuleCheckSettings,
   override val projectCache: ProjectCache,
-  private val gradleLogger: GradleLogger,
+  private val gradleLogger: GradleMcLogger,
   private val buildFileParserFactory: BuildFileParser.Factory,
   private val jvmFileProviderFactory: RealJvmFileProvider.Factory,
   private val androidPlatformPluginFactory: AndroidPlatformPluginFactory,

--- a/modulecheck-plugin/src/main/kotlin/modulecheck/gradle/task/GradleMcLogger.kt
+++ b/modulecheck-plugin/src/main/kotlin/modulecheck/gradle/task/GradleMcLogger.kt
@@ -18,7 +18,7 @@ package modulecheck.gradle.task
 import com.squareup.anvil.annotations.ContributesBinding
 import modulecheck.dagger.AppScope
 import modulecheck.gradle.GradleProject
-import modulecheck.reporting.logging.Logger
+import modulecheck.reporting.logging.McLogger
 import modulecheck.reporting.logging.Report
 import modulecheck.reporting.logging.Report.ReportEntry.Failure
 import modulecheck.reporting.logging.Report.ReportEntry.FailureHeader
@@ -36,9 +36,9 @@ import org.gradle.internal.logging.text.StyledTextOutputFactory
 import javax.inject.Inject
 
 @ContributesBinding(AppScope::class)
-class GradleLogger @Inject constructor(
+class GradleMcLogger @Inject constructor(
   project: GradleProject
-) : Logger {
+) : McLogger {
 
   private val output: StyledTextOutput = project
     .serviceOf<StyledTextOutputFactory>()

--- a/modulecheck-project/api/src/main/kotlin/modulecheck/project/McProject.kt
+++ b/modulecheck-project/api/src/main/kotlin/modulecheck/project/McProject.kt
@@ -27,7 +27,7 @@ import modulecheck.parsing.gradle.SourceSets
 import modulecheck.parsing.gradle.isAndroid
 import modulecheck.parsing.source.AnvilGradlePlugin
 import modulecheck.parsing.source.JavaVersion
-import modulecheck.reporting.logging.Logger
+import modulecheck.reporting.logging.McLogger
 import org.jetbrains.kotlin.name.FqName
 import java.io.File
 
@@ -59,7 +59,7 @@ interface McProject :
   override val hasAnvil: Boolean
     get() = anvilGradlePlugin != null
 
-  val logger: Logger
+  val logger: McLogger
   val jvmFileProviderFactory: JvmFileProvider.Factory
 
   val javaSourceVersion: JavaVersion

--- a/modulecheck-project/impl/src/main/kotlin/modulecheck/project/impl/RealMcProject.kt
+++ b/modulecheck-project/impl/src/main/kotlin/modulecheck/project/impl/RealMcProject.kt
@@ -29,7 +29,7 @@ import modulecheck.project.McProject
 import modulecheck.project.ProjectCache
 import modulecheck.project.ProjectContext
 import modulecheck.project.ProjectDependencies
-import modulecheck.reporting.logging.Logger
+import modulecheck.reporting.logging.McLogger
 import org.jetbrains.kotlin.name.FqName
 import java.io.File
 
@@ -42,7 +42,7 @@ class RealMcProject(
   override val hasTestFixturesPlugin: Boolean,
   override val projectCache: ProjectCache,
   override val anvilGradlePlugin: AnvilGradlePlugin?,
-  override val logger: Logger,
+  override val logger: McLogger,
   override val jvmFileProviderFactory: JvmFileProvider.Factory,
   override val javaSourceVersion: JavaVersion,
   projectDependencies: Lazy<ProjectDependencies>,

--- a/modulecheck-reporting/logging/src/main/kotlin/modulecheck/reporting/logging/McLogger.kt
+++ b/modulecheck-reporting/logging/src/main/kotlin/modulecheck/reporting/logging/McLogger.kt
@@ -27,7 +27,7 @@ import modulecheck.reporting.logging.Report.ReportEntry.SuccessLine
 import modulecheck.reporting.logging.Report.ReportEntry.Warning
 import modulecheck.reporting.logging.Report.ReportEntry.WarningLine
 
-interface Logger {
+interface McLogger {
 
   fun printReport(report: Report)
 

--- a/modulecheck-reporting/logging/src/main/kotlin/modulecheck/reporting/logging/PrintLogger.kt
+++ b/modulecheck-reporting/logging/src/main/kotlin/modulecheck/reporting/logging/PrintLogger.kt
@@ -15,7 +15,7 @@
 
 package modulecheck.reporting.logging
 
-class PrintLogger : Logger {
+class PrintLogger : McLogger {
   override fun printReport(report: Report) {
     println(report.joinToString())
   }

--- a/modulecheck-runtime/src/main/kotlin/modulecheck/runtime/ModuleCheckRunner.kt
+++ b/modulecheck-runtime/src/main/kotlin/modulecheck/runtime/ModuleCheckRunner.kt
@@ -34,7 +34,7 @@ import modulecheck.reporting.console.DepthLogFactory
 import modulecheck.reporting.console.DepthReportFactory
 import modulecheck.reporting.console.ReportFactory
 import modulecheck.reporting.graphviz.GraphvizFileWriter
-import modulecheck.reporting.logging.Logger
+import modulecheck.reporting.logging.McLogger
 import modulecheck.reporting.sarif.SarifReportFactory
 import modulecheck.rule.FindingFactory
 import modulecheck.utils.createSafely
@@ -54,7 +54,7 @@ import kotlin.system.measureTimeMillis
 data class ModuleCheckRunner @AssistedInject constructor(
   val settings: ModuleCheckSettings,
   val findingFactory: FindingFactory<out Finding>,
-  val logger: Logger,
+  val logger: McLogger,
   val findingResultFactory: FindingResultFactory,
   val reportFactory: ReportFactory,
   val checkstyleReporter: CheckstyleReporter,

--- a/modulecheck-runtime/src/testFixtures/kotlin/modulecheck/runtime/test/RunnerTest.kt
+++ b/modulecheck-runtime/src/testFixtures/kotlin/modulecheck/runtime/test/RunnerTest.kt
@@ -32,7 +32,7 @@ import modulecheck.reporting.checkstyle.CheckstyleReporter
 import modulecheck.reporting.console.ReportFactory
 import modulecheck.reporting.graphviz.GraphvizFactory
 import modulecheck.reporting.graphviz.GraphvizFileWriter
-import modulecheck.reporting.logging.Logger
+import modulecheck.reporting.logging.McLogger
 import modulecheck.reporting.sarif.SarifReportFactory
 import modulecheck.rule.FindingFactory
 import modulecheck.rule.RuleFactory
@@ -58,7 +58,7 @@ abstract class RunnerTest : ProjectTest() {
     strictResolution: Boolean = false,
     findingFactory: FindingFactory<out Finding> = this.findingFactory,
     settings: ModuleCheckSettings = this.settings,
-    logger: Logger = this.logger,
+    logger: McLogger = this.logger,
     projectProvider: ProjectProvider = this.projectProvider,
     findingResultFactory: FindingResultFactory = RealFindingResultFactory(),
     reportFactory: ReportFactory = ReportFactory(),


### PR DESCRIPTION
This just distinguishes it from the other 50 "Logger" interfaces in a Gradle plugin's classpath, which makes IDE auto-import happy.