### PR TITLE
disable the "use tab character" option in IDE codestyle

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -126,7 +126,6 @@
         <option name="INDENT_SIZE" value="2" />
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
         <option name="TAB_SIZE" value="2" />
-        <option name="USE_TAB_CHARACTER" value="true" />
       </indentOptions>
     </codeStyleSettings>
   </code_scheme>


### PR DESCRIPTION
Not sure how this got added (by me).  Maybe an IDE update changed the settings and I didn't notice.

Anyways, with this option enabled, any refactoring done via the IDE will use a tab.  Then KtLint gets mad.