### PR TITLE
create a shared `.gradle` cache for TestKit tests

### DIFF
--- a/modulecheck-gradle/plugin/build.gradle.kts
+++ b/modulecheck-gradle/plugin/build.gradle.kts
@@ -25,10 +25,8 @@ mcbuild {
 }
 
 tasks.withType<Test> {
-  if (!System.getenv("CI").isNullOrBlank()) {
-    // Gradle TestKit somewhat regularly runs out of memory on the freebie GitHub runners
-    maxParallelForks = 1
-  }
+  // Gradle TestKit somewhat regularly runs out of memory on the freebie GitHub runners
+  maxParallelForks = 1
 }
 
 dependencies {


### PR DESCRIPTION
This saves about 1m30s, or ~75% of execution time, when executing all TestKit tests on my M1 Max.