### PR TITLE
don't find `must-be-api` if the project is already an api dependency also

### DIFF
--- a/modulecheck-core/src/main/kotlin/modulecheck/core/context/MustBeApi.kt
+++ b/modulecheck-core/src/main/kotlin/modulecheck/core/context/MustBeApi.kt
@@ -100,7 +100,7 @@ data class MustBeApi(
             .distinctBy { it.path }
             .filterNot { cpd ->
               // exclude anything which is inherited but already included in local `api` deps
-              cpd in directApiProjects
+              cpd.copy(configurationName = cpd.configurationName.apiVariant()) in directApiProjects
             }
             .filterAsync {
               !sourceSetName.isTestingOnly() && it.project(project.projectCache)


### PR DESCRIPTION

fixes #662