### PR TITLE
remove the `google()` repository requirement from docs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,6 @@ plugins {
   id("mcbuild.artifacts-check")
   id("mcbuild.ben-manes")
   id("mcbuild.clean")
-  id("mcbuild.dependency-guard")
   id("mcbuild.dokka")
   id("mcbuild.knit")
   id("mcbuild.kotlin")

--- a/website/docs/quickstart.mdx
+++ b/website/docs/quickstart.mdx
@@ -25,8 +25,6 @@ values={[
 pluginManagement {
   repositories {
     gradlePluginPortal()
-    // used for Android Gradle Plugin internally
-    google()
     // Add for SNAPSHOT builds
     maven("https://oss.sonatype.org/content/repositories/snapshots/")
   }
@@ -51,8 +49,6 @@ plugins {
 pluginManagement {
   repositories {
     gradlePluginPortal()
-    // used for Android Gradle Plugin internally
-    google()
     // Add for SNAPSHOT builds
     maven {
       url "https://oss.sonatype.org/content/repositories/snapshots"


### PR DESCRIPTION
The `google()` repository should no longer be mandatory, since AGP is no longer in the plugin's runtime classpath.