### PR TITLE
add a discrete job in CI for publishing to mavenLocal, then cache it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,39 +18,6 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
 
-  website:
-    name: build website
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Check out repo
-        uses: actions/checkout@v3
-
-      # Node is required for npm
-      - name: Set up Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 14.x
-          cache: yarn
-          cache-dependency-path: website/yarn.lock
-
-      - name: Install Yarn
-        working-directory: website
-        run: |
-          yarn install --frozen-lockfile
-
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'adopt'
-          java-version: '11'
-          cache: 'gradle'
-
-      - uses: gradle/wrapper-validation-action@v1
-
-      - name: build website
-        run: ./gradlew buildSite --no-daemon
-
   static-analysis:
 
     runs-on: ubuntu-latest
@@ -226,9 +193,78 @@ jobs:
           commit_message: update website versions
           commit_options: '--no-verify --signoff'
 
+  publish-maven-local:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: check out with token (used by forks)
+        uses: actions/checkout@v3
+        if: github.event.pull_request.head.repo.full_name != github.repository
+
+      - name: check out with PAT (used by main repo)
+        uses: actions/checkout@v3
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          fetch-depth: 0
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+          cache: 'gradle'
+
+      - name: publish to maven local and build tests
+        uses: burrunan/gradle-cache-action@v1
+        with:
+          gradle-dependencies-cache-key: gradle/libs.versions.toml
+          arguments: |
+            publishToMavenLocal
+            buildTests
+          concurrent: true
+          gradle-build-scan-report: false
+
+  website:
+    name: build website
+    runs-on: ubuntu-latest
+    needs: publish-maven-local
+    steps:
+
+      - name: Check out repo
+        uses: actions/checkout@v3
+
+      # Node is required for npm
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+          cache: yarn
+          cache-dependency-path: website/yarn.lock
+
+      - name: Install Yarn
+        working-directory: website
+        run: |
+          yarn install --frozen-lockfile
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+          cache: 'gradle'
+
+      - uses: gradle/wrapper-validation-action@v1
+
+      - name: build website
+        run: ./gradlew buildSite --no-daemon
+
   tests-ubuntu:
 
     runs-on: ubuntu-latest
+    needs: publish-maven-local
 
     steps:
       - name: check out with token (used by forks)
@@ -276,6 +312,7 @@ jobs:
   tests-windows:
 
     runs-on: windows-latest
+    needs: publish-maven-local
 
     steps:
 


### PR DESCRIPTION
The maven local publication is needed for the TestKit integration tests, so that's two different actors.

99.999% of the processing necessary for `publishToMavenLocal` is for doing the actual builds and then generating the KDoc.  All that KDoc is needed when building the website, so that's now three actors.

Since half of the testing is done on a Windows machine, it's probably faster to do all that work and cache it on a Linux machine, then restore on Windows -- even with the added I/O.  That's the theory, anyway.