### PR TITLE
Fix small false-positive for ViewBinding

### DIFF
--- a/modulecheck-rule/impl/src/main/kotlin/modulecheck/rule/impl/DisableViewBindingRule.kt
+++ b/modulecheck-rule/impl/src/main/kotlin/modulecheck/rule/impl/DisableViewBindingRule.kt
@@ -21,6 +21,8 @@ import modulecheck.api.context.referencesForSourceSetName
 import modulecheck.config.ModuleCheckSettings
 import modulecheck.finding.FindingName
 import modulecheck.finding.android.DisableViewBindingGenerationFinding
+import modulecheck.parsing.gradle.model.SourceSetName
+import modulecheck.parsing.gradle.model.SourceSetName.Companion
 import modulecheck.project.McProject
 import modulecheck.project.isAndroid
 import modulecheck.project.project
@@ -52,7 +54,7 @@ class DisableViewBindingRule @Inject constructor() : DocumentedRule<DisableViewB
           .takeIf { it.isNotEmpty() }
           ?: return@forEach
 
-        val usedInProject = sourceSetName.withDownStream(project)
+        val usedInProject = sourceSetName.withDownStream(project).plus(SourceSetName.MAIN)
           .any { sourceSetNameOrDownstream ->
 
             generatedBindings.any { generated ->

--- a/modulecheck-rule/impl/src/main/kotlin/modulecheck/rule/impl/DisableViewBindingRule.kt
+++ b/modulecheck-rule/impl/src/main/kotlin/modulecheck/rule/impl/DisableViewBindingRule.kt
@@ -22,7 +22,6 @@ import modulecheck.config.ModuleCheckSettings
 import modulecheck.finding.FindingName
 import modulecheck.finding.android.DisableViewBindingGenerationFinding
 import modulecheck.parsing.gradle.model.SourceSetName
-import modulecheck.parsing.gradle.model.SourceSetName.Companion
 import modulecheck.project.McProject
 import modulecheck.project.isAndroid
 import modulecheck.project.project


### PR DESCRIPTION
I recently opened #710 about suppressing view binding check. I had to suppress since there was a false positive. I looked into our project more and figured out what was wrong. 

This is coming from `developer-menu` module where we have different layout for debug and release versions. In case you want to have different layout in different build-types, you have to separate them. But then you can use them in main source set when accessing. ModuleCheck does not account for this valid (but uncommon) case.

This PR fixes the issue in most simplest way with a test case. Let me know if this makes sense. I'm not sure if I missed anything. If you have concerns about the change, I hope the test case will be helpful.