### PR TITLE
update ktlint intellij plugin config for 0.46.0

### DIFF
--- a/.idea/ktlint.xml
+++ b/.idea/ktlint.xml
@@ -8,8 +8,9 @@
       <list>
         <option value="max-line-length" />
         <option value="filename" />
-        <option value="experimental:argument-list-wrapping" />
-        <option value="experimental:no-empty-first-line-in-method-block" />
+        <option value="experimental:function-signature" />
+        <option value="argument-list-wrapping" />
+        <option value="no-empty-first-line-in-method-block" />
         <option value="experimental:type-parameter-list-spacing" />
       </list>
     </disabledRules>

--- a/build-logic/mcbuild/src/main/kotlin/mcbuild.ktlint.gradle.kts
+++ b/build-logic/mcbuild/src/main/kotlin/mcbuild.ktlint.gradle.kts
@@ -34,11 +34,18 @@ extensions.configure(KtlintExtension::class.java) {
       "experimental:no-empty-first-line-in-method-block", // code golf...
       // This can be re-enabled once 0.46.0 is released
       // https://github.com/pinterest/ktlint/issues/1435
-      "experimental:type-parameter-list-spacing"
+      "experimental:type-parameter-list-spacing",
+      // added in 0.46.0
+      "experimental:function-signature"
     )
   )
   require(libsCatalog.version("ktlint-lib").requiredVersion < "0.46.0") {
-    "Re-enable the `experimental:type-parameter-list-spacing` rule when updating to 0.46.0."
+    """
+    when updating to 0.46.0:
+    - Re-enable `experimental:type-parameter-list-spacing`
+    - remove 'experimental' from 'argument-list-wrapping'
+    - remove 'experimental' from 'no-empty-first-line-in-method-block'
+    """.trimIndent()
   }
 }
 


### PR DESCRIPTION
The IntelliJ plugin automatically updates the KtLint version.  `0.46.0` promoted some experimental rules to stable, and introduced 'experimental:function-signature' which is definitely very opinionated and wrong.