### PR TITLE
allow multiple `overshot-dependency` findings for the same project dependency if the new configuration is different

### DIFF
--- a/modulecheck-core/src/main/kotlin/modulecheck/core/context/OverShotDependencies.kt
+++ b/modulecheck-core/src/main/kotlin/modulecheck/core/context/OverShotDependencies.kt
@@ -125,7 +125,10 @@ data class OverShotDependencies(
           )
         }
         .sortedBy { it.newDependency.identifier.name }
-        .distinctBy { it.newDependency.identifier }
+        // Only report each new path/configuration pair once.  So we can add multiple dependencies
+        // for the `testImplementation` config, or multiple configurations of the `:lib1` project,
+        // but we'll only add `testImplementation(project(":lib1"))` once.
+        .distinctBy { it.newDependency.identifier to it.newDependency.configurationName }
     }
   }
 

--- a/modulecheck-runtime/testing/src/main/kotlin/modulecheck/runtime/test/RunnerTest.kt
+++ b/modulecheck-runtime/testing/src/main/kotlin/modulecheck/runtime/test/RunnerTest.kt
@@ -144,7 +144,15 @@ abstract class RunnerTest : ProjectTest() {
   }
 
   private fun List<Pair<String, List<ProjectFindingReport>>>.sorted() = sortedBy { it.first }
-    .map { it.first to it.second.sortedBy { it::class.java.simpleName } }
+    .map { (path, findings) ->
+      path to findings.sortedBy { findingReport ->
+
+        val findingName = findingReport::class.java.simpleName
+        val config = findingReport.configuration ?: "-"
+
+        "$findingName$config${findingReport.position}"
+      }
+    }
 
   infix fun List<Pair<String, List<ProjectFindingReport>>>.shouldBe(
     expected: List<Pair<String, List<ProjectFindingReport>>>


### PR DESCRIPTION
fixes #809