### PR TITLE
split up long-running Actions jobs for caching purposes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  macosGradleArgs: '-Dorg.gradle.jvmargs=-Xmx10g -Dfile.encoding=UTF-8 -XX:+UseParallelGC'
+  ubuntuGradleArgs: '-Dorg.gradle.jvmargs=-Xmx5g -Dfile.encoding=UTF-8 -XX:+UseParallelGC'
+  windowsGradleArgs: '-Dorg.gradle.jvmargs=-Xmx5g -Dfile.encoding=UTF-8 -XX:+UseParallelGC'
 
 jobs:
 
@@ -256,8 +260,7 @@ jobs:
 
       - name: Install Yarn
         working-directory: website
-        run: |
-          yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile
 
       - uses: gradle/wrapper-validation-action@v1
 
@@ -267,12 +270,22 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
 
-      - name: build website
+      - name: compileKotlin
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: |
-            buildSite
-            "-Dorg.gradle.jvmargs=-Xmx10g -Dfile.encoding=UTF-8 -XX:+UseParallelGC"
+          arguments: compileKotlin "${{ env.macosGradleArgs }}"
+          cache-read-only: false
+
+      - name: dokkaHtmlMultiModule
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: dokkaHtmlMultiModule "${{ env.macosGradleArgs }}"
+          cache-read-only: false
+
+      - name: buildSite
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: buildSite "${{ env.macosGradleArgs }}"
           cache-read-only: false
 
       - name: knit check
@@ -307,9 +320,7 @@ jobs:
       - name: all tests
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: |
-            test
-            "-Dorg.gradle.jvmargs=-Xmx10g -Dfile.encoding=UTF-8 -XX:+UseParallelGC"
+          arguments: test "${{ env.macosGradleArgs }}"
           cache-read-only: false
 
       - name: Archive test results
@@ -350,12 +361,16 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
 
+      - name: publishToMavenLocal
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: publishToMavenLocalNoDokka "${{ env.macosGradleArgs }}"
+          cache-read-only: false
+
       - name: integration tests
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: |
-            integrationTest
-            "-Dorg.gradle.jvmargs=-Xmx10g -Dfile.encoding=UTF-8 -XX:+UseParallelGC"
+          arguments: integrationTest "${{ env.macosGradleArgs }}"
           cache-read-only: false
 
       - name: Archive integration test results
@@ -400,9 +415,7 @@ jobs:
       - name: all tests
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: |
-            test
-            "-Dorg.gradle.jvmargs=-Xmx6g -Dfile.encoding=UTF-8 -XX:+UseParallelGC"
+          arguments: test "${{ env.windowsGradleArgs }}"
           cache-read-only: false
 
       - name: Archive test results
@@ -445,12 +458,16 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
 
+      - name: publishToMavenLocal
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: publishToMavenLocalNoDokka "${{ env.windowsGradleArgs }}"
+          cache-read-only: false
+
       - name: integration tests
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: |
-            integrationTest
-            "-Dorg.gradle.jvmargs=-Xmx6g -Dfile.encoding=UTF-8 -XX:+UseParallelGC"
+          arguments: integrationTest "${{ env.windowsGradleArgs }}"
           cache-read-only: false
 
       - name: Archive integration test results

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -6,22 +6,40 @@ on:
     branches:
       - main
 
+env:
+  gradleArgs: '-Dorg.gradle.jvmargs=-Xmx10g -Dfile.encoding=UTF-8 -XX:+UseParallelGC'
+
 jobs:
   publish-snapshot:
     runs-on: macos-latest
     if: github.repository == 'RBusarow/ModuleCheck'
-    timeout-minutes: 25
+    timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'zulu'
           java-version: '11'
-          check-latest: true
+
+      # break the publishing builds down a little into smaller steps
+      # because gradle-build-action's caching is all-or-nothing.  If the full publish task
+      # takes too long and times out, no cache is retained.
+
+      - name: Compile Kotlin
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: compileKotlin "${{ env.gradleArgs }}"
+
+      - name: Dokka & JavadocJar
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: dokkaJavadocJar "${{ env.gradleArgs }}"
 
       - name: Publish Snapshots
-        run: ./gradlew clean publish --no-build-cache --no-daemon --stacktrace --no-parallel "-Dorg.gradle.jvmargs=-Xmx10g -Dfile.encoding=UTF-8 -XX:+UseParallelGC"
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: publish --no-parallel "${{ env.gradleArgs }}"
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -7,6 +7,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  gradleArgs: '-Dorg.gradle.jvmargs=-Xmx6g -Dfile.encoding=UTF-8 -XX:+UseParallelGC'
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   publish:
@@ -27,22 +30,30 @@ jobs:
 
       - name: Install Yarn
         working-directory: website
-        run: |
-          yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile
 
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'zulu'
           java-version: '11'
-          cache: 'gradle'
 
-      - uses: gradle/wrapper-validation-action@v1
+      - name: compileKotlin
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: compileKotlin "${{ env.gradleArgs }}"
+          cache-read-only: false
+
+      - name: dokkaHtmlMultiModule
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: dokkaHtmlMultiModule "${{ env.gradleArgs }}"
+          cache-read-only: false
 
       - name: build website
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: buildSite
+          arguments: buildSite "${{ env.gradleArgs }}"
           cache-read-only: false
 
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
If a job times out or just gets cancelled, `gradle-build-action` won't cache anything.  However, if an upstream task using the same action was already completed, that one *will* get cached.

So if for example builds/dokka/tests are split into different stages, and the last one gets cancelled, the results of the first two will still be cached.  This means that subsequent attempts will be faster.