### PR TITLE
clean up unused repository declarations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 env:
   macosGradleArgs: '-Dorg.gradle.jvmargs=-Xmx10g -Dfile.encoding=UTF-8 -XX:+UseParallelGC'
   ubuntuGradleArgs: '-Dorg.gradle.jvmargs=-Xmx5g -Dfile.encoding=UTF-8 -XX:+UseParallelGC'
-  windowsGradleArgs: '-Dorg.gradle.jvmargs=-Xmx5g -Dfile.encoding=UTF-8 -XX:+UseParallelGC'
+  windowsGradleArgs: '-Dorg.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8 -XX:+UseParallelGC'
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,17 +299,8 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - name: check out with token (used by forks)
+      - name: check out with token
         uses: actions/checkout@v3
-        if: github.event.pull_request.head.repo.full_name != github.repository
-
-      - name: check out with PAT (used by main repo)
-        uses: actions/checkout@v3
-        if: github.event.pull_request.head.repo.full_name == github.repository
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          fetch-depth: 0
 
       - name: Set up JDK
         uses: actions/setup-java@v3
@@ -343,17 +334,8 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - name: check out with token (used by forks)
+      - name: check out with token
         uses: actions/checkout@v3
-        if: github.event.pull_request.head.repo.full_name != github.repository
-
-      - name: check out with PAT (used by main repo)
-        uses: actions/checkout@v3
-        if: github.event.pull_request.head.repo.full_name == github.repository
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          fetch-depth: 0
 
       - name: Set up JDK
         uses: actions/setup-java@v3
@@ -394,17 +376,8 @@ jobs:
 
     steps:
 
-      - name: check out with token (used by forks)
+      - name: check out with token
         uses: actions/checkout@v3
-        if: github.event.pull_request.head.repo.full_name != github.repository
-
-      - name: check out with PAT (used by main repo)
-        uses: actions/checkout@v3
-        if: github.event.pull_request.head.repo.full_name == github.repository
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          fetch-depth: 0
 
       - name: Set up JDK
         uses: actions/setup-java@v3
@@ -440,17 +413,8 @@ jobs:
 
     steps:
 
-      - name: check out with token (used by forks)
+      - name: check out
         uses: actions/checkout@v3
-        if: github.event.pull_request.head.repo.full_name != github.repository
-
-      - name: check out with PAT (used by main repo)
-        uses: actions/checkout@v3
-        if: github.event.pull_request.head.repo.full_name == github.repository
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          fetch-depth: 0
 
       - name: Set up JDK
         uses: actions/setup-java@v3

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -13,25 +13,22 @@
  * limitations under the License.
  */
 
+rootProject.name = "build-logic"
 enableFeaturePreview("VERSION_CATALOGS")
 
 pluginManagement {
-  @Suppress("UnstableApiUsage")
   repositories {
-    google()
     mavenCentral()
-    mavenLocal()
+    google()
     maven("https://plugins.gradle.org/m2/")
-    maven("https://oss.sonatype.org/content/repositories/snapshots")
   }
 }
 
 dependencyResolutionManagement {
   @Suppress("UnstableApiUsage")
   repositories {
-    google()
     mavenCentral()
-    mavenLocal()
+    google()
     maven("https://plugins.gradle.org/m2/")
   }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,7 +25,6 @@ pluginManagement {
         includeGroup("com.rickbusarow.modulecheck")
       }
     }
-    mavenLocal()
   }
   @Suppress("UnstableApiUsage")
   includeBuild("build-logic")
@@ -34,11 +33,9 @@ pluginManagement {
 dependencyResolutionManagement {
   @Suppress("UnstableApiUsage")
   repositories {
-    google()
     mavenCentral()
-    mavenLocal()
+    google()
     maven("https://plugins.gradle.org/m2/")
-    maven("https://oss.sonatype.org/content/repositories/snapshots/")
   }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,7 +43,7 @@ dependencyResolutionManagement {
 }
 
 plugins {
-  id("com.gradle.enterprise").version("3.5.2")
+  id("com.gradle.enterprise").version("3.11.1")
 }
 
 gradleEnterprise {


### PR DESCRIPTION
This is mostly for the sake of (significantly) faster dependency resolution during the `dependencyUpdates` task.  Having the snapshots repository wide open -- when it isn't even used -- means that the Ben Manes plugin will resolve every single snapshot version of every dependency.  This is mostly a problem with Kotest, which can take as much as 10 minutes to resolve every single version/artifact.