### PR TITLE
better management of `RealKotlinEnvironment` state

### DIFF
--- a/dependency-guard-aggregate.txt
+++ b/dependency-guard-aggregate.txt
@@ -597,7 +597,8 @@
 :modulecheck-project:testing -- runtimeClasspath -- javax.inject:javax.inject:1
 :modulecheck-project:testing -- runtimeClasspath -- net.bytebuddy:byte-buddy-agent:1.12.6
 :modulecheck-project:testing -- runtimeClasspath -- net.bytebuddy:byte-buddy:1.12.6
-:modulecheck-project:testing -- runtimeClasspath -- net.java.dev.jna:jna:5.6.0
+:modulecheck-project:testing -- runtimeClasspath -- net.java.dev.jna:jna-platform:5.9.0
+:modulecheck-project:testing -- runtimeClasspath -- net.java.dev.jna:jna:5.9.0
 :modulecheck-project:testing -- runtimeClasspath -- net.swiftzer.semver:semver:1.2.0
 :modulecheck-project:testing -- runtimeClasspath -- org.abego.treelayout:org.abego.treelayout.core:1.0.3
 :modulecheck-project:testing -- runtimeClasspath -- org.antlr:ST4:4.3.4
@@ -621,6 +622,7 @@
 :modulecheck-project:testing -- runtimeClasspath -- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4
 :modulecheck-project:testing -- runtimeClasspath -- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4
 :modulecheck-project:testing -- runtimeClasspath -- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4
+:modulecheck-project:testing -- runtimeClasspath -- org.jetbrains.kotlinx:kotlinx-coroutines-debug:1.6.4
 :modulecheck-project:testing -- runtimeClasspath -- org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4
 :modulecheck-project:testing -- runtimeClasspath -- org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm:1.6.4
 :modulecheck-project:testing -- runtimeClasspath -- org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4
@@ -987,7 +989,8 @@
 :modulecheck-runtime:testing -- runtimeClasspath -- javax.inject:javax.inject:1
 :modulecheck-runtime:testing -- runtimeClasspath -- net.bytebuddy:byte-buddy-agent:1.12.6
 :modulecheck-runtime:testing -- runtimeClasspath -- net.bytebuddy:byte-buddy:1.12.6
-:modulecheck-runtime:testing -- runtimeClasspath -- net.java.dev.jna:jna:5.6.0
+:modulecheck-runtime:testing -- runtimeClasspath -- net.java.dev.jna:jna-platform:5.9.0
+:modulecheck-runtime:testing -- runtimeClasspath -- net.java.dev.jna:jna:5.9.0
 :modulecheck-runtime:testing -- runtimeClasspath -- net.swiftzer.semver:semver:1.2.0
 :modulecheck-runtime:testing -- runtimeClasspath -- org.abego.treelayout:org.abego.treelayout.core:1.0.3
 :modulecheck-runtime:testing -- runtimeClasspath -- org.antlr:ST4:4.3.4
@@ -1011,6 +1014,7 @@
 :modulecheck-runtime:testing -- runtimeClasspath -- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4
 :modulecheck-runtime:testing -- runtimeClasspath -- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4
 :modulecheck-runtime:testing -- runtimeClasspath -- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4
+:modulecheck-runtime:testing -- runtimeClasspath -- org.jetbrains.kotlinx:kotlinx-coroutines-debug:1.6.4
 :modulecheck-runtime:testing -- runtimeClasspath -- org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4
 :modulecheck-runtime:testing -- runtimeClasspath -- org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm:1.6.4
 :modulecheck-runtime:testing -- runtimeClasspath -- org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4
@@ -1031,7 +1035,13 @@
 :modulecheck-utils:cache -- runtimeClasspath -- com.github.ben-manes.caffeine:caffeine:3.1.1
 :modulecheck-utils:cache -- runtimeClasspath -- com.google.errorprone:error_prone_annotations:2.14.0
 :modulecheck-utils:cache -- runtimeClasspath -- com.rickbusarow.dispatch:dispatch-core:1.0.0-beta10
+:modulecheck-utils:cache -- runtimeClasspath -- net.java.dev.jna:jna:5.6.0
 :modulecheck-utils:cache -- runtimeClasspath -- org.checkerframework:checker-qual:3.22.0
+:modulecheck-utils:cache -- runtimeClasspath -- org.jetbrains.intellij.deps:trove4j:1.0.20200330
+:modulecheck-utils:cache -- runtimeClasspath -- org.jetbrains.kotlin:kotlin-compiler-embeddable:1.6.21
+:modulecheck-utils:cache -- runtimeClasspath -- org.jetbrains.kotlin:kotlin-daemon-embeddable:1.6.21
+:modulecheck-utils:cache -- runtimeClasspath -- org.jetbrains.kotlin:kotlin-reflect:1.6.21
+:modulecheck-utils:cache -- runtimeClasspath -- org.jetbrains.kotlin:kotlin-script-runtime:1.6.21
 :modulecheck-utils:cache -- runtimeClasspath -- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21
 :modulecheck-utils:cache -- runtimeClasspath -- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21
 :modulecheck-utils:cache -- runtimeClasspath -- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21
@@ -1042,6 +1052,12 @@
 :modulecheck-utils:cache -- runtimeClasspath -- org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4
 :modulecheck-utils:cache -- runtimeClasspath -- org.jetbrains:annotations:13.0
 
+:modulecheck-utils:lazy -- runtimeClasspath -- net.java.dev.jna:jna:5.6.0
+:modulecheck-utils:lazy -- runtimeClasspath -- org.jetbrains.intellij.deps:trove4j:1.0.20200330
+:modulecheck-utils:lazy -- runtimeClasspath -- org.jetbrains.kotlin:kotlin-compiler-embeddable:1.6.21
+:modulecheck-utils:lazy -- runtimeClasspath -- org.jetbrains.kotlin:kotlin-daemon-embeddable:1.6.21
+:modulecheck-utils:lazy -- runtimeClasspath -- org.jetbrains.kotlin:kotlin-reflect:1.6.21
+:modulecheck-utils:lazy -- runtimeClasspath -- org.jetbrains.kotlin:kotlin-script-runtime:1.6.21
 :modulecheck-utils:lazy -- runtimeClasspath -- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21
 :modulecheck-utils:lazy -- runtimeClasspath -- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21
 :modulecheck-utils:lazy -- runtimeClasspath -- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21

--- a/detekt/detekt-baseline.xml
+++ b/detekt/detekt-baseline.xml
@@ -212,16 +212,6 @@
     <ID>UndocumentedPublicClass:McLogger.kt$Report$ReportBuilder</ID>
     <ID>UndocumentedPublicClass:McLogger.kt$Report$ReportEntry</ID>
     <ID>UndocumentedPublicClass:McLogger.kt$Report.ReportEntry$AppendNewLine</ID>
-    <ID>UndocumentedPublicClass:McLogger.kt$Report.ReportEntry$Failure : ReportEntry</ID>
-    <ID>UndocumentedPublicClass:McLogger.kt$Report.ReportEntry$FailureHeader : ReportEntryAppendNewLine</ID>
-    <ID>UndocumentedPublicClass:McLogger.kt$Report.ReportEntry$FailureLine : ReportEntryAppendNewLine</ID>
-    <ID>UndocumentedPublicClass:McLogger.kt$Report.ReportEntry$Header : ReportEntryAppendNewLine</ID>
-    <ID>UndocumentedPublicClass:McLogger.kt$Report.ReportEntry$Info : ReportEntryAppendNewLine</ID>
-    <ID>UndocumentedPublicClass:McLogger.kt$Report.ReportEntry$Success : ReportEntry</ID>
-    <ID>UndocumentedPublicClass:McLogger.kt$Report.ReportEntry$SuccessHeader : ReportEntryAppendNewLine</ID>
-    <ID>UndocumentedPublicClass:McLogger.kt$Report.ReportEntry$SuccessLine : ReportEntryAppendNewLine</ID>
-    <ID>UndocumentedPublicClass:McLogger.kt$Report.ReportEntry$Warning : ReportEntry</ID>
-    <ID>UndocumentedPublicClass:McLogger.kt$Report.ReportEntry$WarningLine : ReportEntryAppendNewLine</ID>
     <ID>UndocumentedPublicClass:McProject.kt$McProject : ProjectContextComparableHasPathHasProjectCacheHasBuildFileHasConfigurationsHasDependenciesHasSourceSetsHasDependencyDeclarationsInvokesConfigurationNamesHasPlatformPluginPluginAware</ID>
     <ID>UndocumentedPublicClass:McProjectBuilder.kt$McProjectBuilder&lt;P : PlatformPluginBuilder&lt;*>> : HasDependencyDeclarationsInvokesConfigurationNamesHasDependencies</ID>
     <ID>UndocumentedPublicClass:McSourceSet.kt$HasSourceSets</ID>
@@ -393,9 +383,6 @@
     <ID>UndocumentedPublicClass:XmlFile.kt$XmlFile : HasReferences</ID>
     <ID>UndocumentedPublicClass:XmlFile.kt$XmlFile$LayoutFile : XmlFile</ID>
     <ID>UndocumentedPublicClass:XmlFile.kt$XmlFile$ManifestFile : XmlFile</ID>
-    <ID>UndocumentedPublicClass:lazy.kt$LazyResets&lt;out T : Any> : LazyResets</ID>
-    <ID>UndocumentedPublicClass:lazy.kt$ResetManager</ID>
-    <ID>UndocumentedPublicClass:lazy.kt$Resets</ID>
     <ID>UndocumentedPublicFunction:AbstractDependenciesBlock.kt$AbstractDependenciesBlock$fun addNonModuleStatement( configName: ConfigurationName, parsedString: String, coordinates: MavenCoordinates, suppressed: List&lt;String> )</ID>
     <ID>UndocumentedPublicFunction:AbstractDependenciesBlock.kt$AbstractDependenciesBlock$fun addUnknownStatement( configName: ConfigurationName, parsedString: String, argument: String, suppressed: List&lt;String> )</ID>
     <ID>UndocumentedPublicFunction:AbstractDependenciesBlock.kt$DependenciesBlocksProvider$suspend fun get(): List&lt;DependenciesBlock></ID>
@@ -413,8 +400,8 @@
     <ID>UndocumentedPublicFunction:AndroidDataBindingDeclarations.kt$suspend fun ProjectContext.androidDataBindingDeclarations(): AndroidDataBindingDeclarations</ID>
     <ID>UndocumentedPublicFunction:AndroidDataBindingDeclarations.kt$suspend fun ProjectContext.androidDataBindingDeclarationsForSourceSetName( sourceSetName: SourceSetName ): LazySet&lt;AndroidDataBindingDeclaredName></ID>
     <ID>UndocumentedPublicFunction:AndroidDataBindingNameProvider.kt$AndroidDataBindingNameProvider$suspend fun get(): LazySet&lt;AndroidDataBindingDeclaredName></ID>
-    <ID>UndocumentedPublicFunction:AndroidGradleSettings.kt$AndroidGradleParser$fun parse(buildFile: File): AndroidGradleSettings</ID>
-    <ID>UndocumentedPublicFunction:AndroidGradleSettings.kt$AndroidGradleSettingsProvider$fun get(): AndroidGradleSettings</ID>
+    <ID>UndocumentedPublicFunction:AndroidGradleSettings.kt$AndroidGradleParser$suspend fun parse(buildFile: File): AndroidGradleSettings</ID>
+    <ID>UndocumentedPublicFunction:AndroidGradleSettings.kt$AndroidGradleSettingsProvider$suspend fun get(): AndroidGradleSettings</ID>
     <ID>UndocumentedPublicFunction:AndroidGradleSettings.kt$AndroidGradleSettingsProvider.Factory$fun create(buildFile: File): AndroidGradleSettingsProvider</ID>
     <ID>UndocumentedPublicFunction:AndroidLayoutParser.kt$AndroidLayoutParser$fun parseResources(file: File): Set&lt;String></ID>
     <ID>UndocumentedPublicFunction:AndroidLayoutParser.kt$AndroidLayoutParser$fun parseViews(file: File): Set&lt;String></ID>
@@ -562,34 +549,12 @@
     <ID>UndocumentedPublicFunction:LazySet.kt$fun &lt;E> lazySet( priority: Priority = MEDIUM, dataSource: suspend () -> Set&lt;E> ): LazySet&lt;E></ID>
     <ID>UndocumentedPublicFunction:LazySet.kt$fun &lt;E> lazySet( vararg children: LazySetComponent&lt;E> ): LazySet&lt;E></ID>
     <ID>UndocumentedPublicFunction:LazySet.kt$suspend fun &lt;T : B, E : B, B> LazySet&lt;T>.containsAny(elements: Collection&lt;E>): Boolean</ID>
-    <ID>UndocumentedPublicFunction:LazySet.kt$suspend fun &lt;T : B, E : B, B> LazySet&lt;T>.containsAny(elements: LazySet&lt;E>): Boolean</ID>
     <ID>UndocumentedPublicFunction:ManifestFiles.kt$ManifestFiles$suspend fun get(sourceSetName: SourceSetName): XmlFile.ManifestFile?</ID>
     <ID>UndocumentedPublicFunction:ManifestFiles.kt$suspend fun ProjectContext.manifestFileForSourceSetName( sourceSetName: SourceSetName ): XmlFile.ManifestFile?</ID>
     <ID>UndocumentedPublicFunction:ManifestFiles.kt$suspend fun ProjectContext.manifestFiles(): ManifestFiles</ID>
     <ID>UndocumentedPublicFunction:MavenCoordinates.kt$MavenCoordinates.Companion$fun parseOrNull(coordinateString: String): MavenCoordinates?</ID>
-    <ID>UndocumentedPublicFunction:McLogger.kt$McLogger$fun printFailure(message: String)</ID>
-    <ID>UndocumentedPublicFunction:McLogger.kt$McLogger$fun printFailureHeader(message: String)</ID>
-    <ID>UndocumentedPublicFunction:McLogger.kt$McLogger$fun printFailureLine(message: String)</ID>
-    <ID>UndocumentedPublicFunction:McLogger.kt$McLogger$fun printHeader(message: String)</ID>
-    <ID>UndocumentedPublicFunction:McLogger.kt$McLogger$fun printInfo(message: String)</ID>
-    <ID>UndocumentedPublicFunction:McLogger.kt$McLogger$fun printReport(report: Report)</ID>
-    <ID>UndocumentedPublicFunction:McLogger.kt$McLogger$fun printSuccess(message: String)</ID>
-    <ID>UndocumentedPublicFunction:McLogger.kt$McLogger$fun printSuccessHeader(message: String)</ID>
-    <ID>UndocumentedPublicFunction:McLogger.kt$McLogger$fun printSuccessLine(message: String)</ID>
-    <ID>UndocumentedPublicFunction:McLogger.kt$McLogger$fun printWarning(message: String)</ID>
-    <ID>UndocumentedPublicFunction:McLogger.kt$McLogger$fun printWarningLine(message: String)</ID>
     <ID>UndocumentedPublicFunction:McLogger.kt$Report$fun joinToString(): String</ID>
     <ID>UndocumentedPublicFunction:McLogger.kt$Report.Companion$fun build(buildAction: ReportBuilder.() -> Unit): Report</ID>
-    <ID>UndocumentedPublicFunction:McLogger.kt$Report.ReportBuilder$fun failure(message: String)</ID>
-    <ID>UndocumentedPublicFunction:McLogger.kt$Report.ReportBuilder$fun failureHeader(message: String)</ID>
-    <ID>UndocumentedPublicFunction:McLogger.kt$Report.ReportBuilder$fun failureLine(message: String)</ID>
-    <ID>UndocumentedPublicFunction:McLogger.kt$Report.ReportBuilder$fun header(message: String)</ID>
-    <ID>UndocumentedPublicFunction:McLogger.kt$Report.ReportBuilder$fun info(message: String)</ID>
-    <ID>UndocumentedPublicFunction:McLogger.kt$Report.ReportBuilder$fun success(message: String)</ID>
-    <ID>UndocumentedPublicFunction:McLogger.kt$Report.ReportBuilder$fun successHeader(message: String)</ID>
-    <ID>UndocumentedPublicFunction:McLogger.kt$Report.ReportBuilder$fun successLine(message: String)</ID>
-    <ID>UndocumentedPublicFunction:McLogger.kt$Report.ReportBuilder$fun warning(message: String)</ID>
-    <ID>UndocumentedPublicFunction:McLogger.kt$Report.ReportBuilder$fun warningLine(message: String)</ID>
     <ID>UndocumentedPublicFunction:McLogger.kt$Report.ReportEntry$fun printToStdOut()</ID>
     <ID>UndocumentedPublicFunction:McProject.kt$fun McProject.isAndroid(): Boolean</ID>
     <ID>UndocumentedPublicFunction:McProjectBuilder.kt$McProjectBuilder$@Suppress("LongParameterList") fun addSourceSet( name: SourceSetName, jvmFiles: Set&lt;File> = emptySet(), resourceFiles: Set&lt;File> = emptySet(), layoutFiles: Set&lt;File> = emptySet(), upstreamNames: List&lt;SourceSetName> = emptyList(), downstreamNames: List&lt;SourceSetName> = emptyList() ): SourceSetBuilder</ID>
@@ -628,12 +593,13 @@
     <ID>UndocumentedPublicFunction:PlatformPlugin.kt$fun PlatformPlugin.isAndroid(): Boolean</ID>
     <ID>UndocumentedPublicFunction:PlatformPluginBuilder.kt$PlatformPluginBuilder$fun toPlugin( safeAnalysisResultAccess: SafeAnalysisResultAccess, projectPath: StringProjectPath, projectDependencies: ProjectDependencies, externalDependencies: ExternalDependencies ): T</ID>
     <ID>UndocumentedPublicFunction:PluginsBlock.kt$PluginsBlock$fun getById(pluginId: String): PluginDeclaration?</ID>
-    <ID>UndocumentedPublicFunction:PluginsBlock.kt$PluginsBlockProvider$fun get(): PluginsBlock?</ID>
+    <ID>UndocumentedPublicFunction:PluginsBlock.kt$PluginsBlockProvider$suspend fun get(): PluginsBlock?</ID>
     <ID>UndocumentedPublicFunction:PluginsBlock.kt$PluginsBlockProvider.Factory$fun create(buildFile: File): PluginsBlockProvider</ID>
     <ID>UndocumentedPublicFunction:ProjectAccessor.kt$ProjectAccessor.Companion$fun from(rawString: String, projectPath: ProjectPath): ProjectAccessor</ID>
     <ID>UndocumentedPublicFunction:ProjectCache.kt$ProjectCache$fun clearContexts()</ID>
     <ID>UndocumentedPublicFunction:ProjectCache.kt$ProjectCache$fun getValue(path: ProjectPath): McProject</ID>
     <ID>UndocumentedPublicFunction:ProjectCache.kt$ProjectCache$operator fun set(path: ProjectPath, project: McProject): McProject?</ID>
+    <ID>UndocumentedPublicFunction:ProjectCollector.kt$ProjectCollector$@Contract(pure = true, value = "_->new") suspend fun McProject.editSimple( config: McProjectBuilder&lt;PlatformPluginBuilder&lt;PlatformPlugin>>.() -> Unit = {} ): McProject</ID>
     <ID>UndocumentedPublicFunction:ProjectCollector.kt$ProjectCollector$fun allProjects(): List&lt;McProject></ID>
     <ID>UndocumentedPublicFunction:ProjectCollector.kt$ProjectCollector$fun androidApplication( path: String, androidPackage: String, config: McProjectBuilder&lt;AndroidApplicationPluginBuilder>.() -> Unit = {} ): McProject</ID>
     <ID>UndocumentedPublicFunction:ProjectCollector.kt$ProjectCollector$fun androidDynamicFeature( path: String, androidPackage: String, config: McProjectBuilder&lt;AndroidDynamicFeaturePluginBuilder>.() -> Unit = {} ): McProject</ID>
@@ -644,7 +610,6 @@
     <ID>UndocumentedPublicFunction:ProjectCollector.kt$ProjectCollector$fun simpleProject( buildFileText: String? = null, path: String = ":lib" )</ID>
     <ID>UndocumentedPublicFunction:ProjectCollector.kt$ProjectCollector$operator fun File.invoke(text: () -> String)</ID>
     <ID>UndocumentedPublicFunction:ProjectCollector.kt$ProjectCollector$suspend fun &lt;P : PlatformPluginBuilder&lt;*>> McProject.toProjectBuilder(): McProjectBuilder&lt;P></ID>
-    <ID>UndocumentedPublicFunction:ProjectCollector.kt$ProjectCollector$suspend fun McProject.editSimple( config: McProjectBuilder&lt;PlatformPluginBuilder&lt;PlatformPlugin>>.() -> Unit = {} ): McProject</ID>
     <ID>UndocumentedPublicFunction:ProjectCollector.kt$ProjectCollector$suspend fun PlatformPlugin.toBuilder(): PlatformPluginBuilder&lt;*></ID>
     <ID>UndocumentedPublicFunction:ProjectCollector.kt$ProjectCollector$suspend fun resolveReferences()</ID>
     <ID>UndocumentedPublicFunction:ProjectContext.kt$ProjectContext$fun clearContext()</ID>
@@ -668,9 +633,6 @@
     <ID>UndocumentedPublicFunction:PsiElementResolver.kt$PsiElementResolver$suspend fun declaredNameOrNull( token: PsiElement ): QualifiedDeclaredName?</ID>
     <ID>UndocumentedPublicFunction:PublicDependencies.kt$suspend fun ProjectContext.publicDependencies(): PublicDependencies</ID>
     <ID>UndocumentedPublicFunction:RealAndroidPlatformPluginFactory.kt$RealAndroidPlatformPluginFactory.Type.Companion$fun from(extension: AndroidCommonExtension): Type&lt;*></ID>
-    <ID>UndocumentedPublicFunction:RealAndroidSourceSetsParser.kt$RealAndroidSourceSetsParser$fun String.removeAndroidTestPrefix(): SourceSetName</ID>
-    <ID>UndocumentedPublicFunction:RealAndroidSourceSetsParser.kt$RealAndroidSourceSetsParser$fun String.removeTestFixturesPrefix(): SourceSetName</ID>
-    <ID>UndocumentedPublicFunction:RealAndroidSourceSetsParser.kt$RealAndroidSourceSetsParser$fun String.removeTestPrefix(): String</ID>
     <ID>UndocumentedPublicFunction:RealJavaFile.kt$fun &lt;T> T.canBeImported(): Boolean</ID>
     <ID>UndocumentedPublicFunction:RealJavaFile.kt$fun &lt;T> T.canBeResolved(): Boolean</ID>
     <ID>UndocumentedPublicFunction:RealJavaFile.kt$fun FieldDeclaration.apiReferences(): List&lt;String></ID>
@@ -766,12 +728,7 @@
     <ID>UndocumentedPublicFunction:ktCallableDeclaration.kt$fun KtFunction.jvmNameOrNull(): String?</ID>
     <ID>UndocumentedPublicFunction:ktCallableDeclaration.kt$fun KtProperty.isJvmField(): Boolean</ID>
     <ID>UndocumentedPublicFunction:ktCallableDeclaration.kt$fun KtPropertyAccessor.jvmNameOrNull(): String?</ID>
-    <ID>UndocumentedPublicFunction:lazy.kt$ResetManager$fun register(delegate: Resets)</ID>
-    <ID>UndocumentedPublicFunction:lazy.kt$ResetManager$fun resetAll()</ID>
-    <ID>UndocumentedPublicFunction:lazy.kt$Resets$fun reset()</ID>
-    <ID>UndocumentedPublicFunction:lazy.kt$fun &lt;T : Any> LazyResets( resetManager: ResetManager, valueFactory: suspend () -> T ): LazyResets&lt;T></ID>
     <ID>UndocumentedPublicFunction:lazy.kt$fun &lt;T> unsafeLazy(initializer: () -> T): Lazy&lt;T></ID>
-    <ID>UndocumentedPublicFunction:lazy.kt$inline fun &lt;reified T : Any> ResetManager.lazyResets( noinline valueFactory: suspend () -> T ): LazyResets&lt;T></ID>
     <ID>UndocumentedPublicFunction:list.kt$fun List&lt;String>.positionOf( path: String, configuration: ConfigurationName ): Position?</ID>
     <ID>UndocumentedPublicFunction:mcProject.kt$suspend fun ConfiguredDependency.positionIn( dependentProject: McProject ): Position?</ID>
     <ID>UndocumentedPublicFunction:mcProject.kt$suspend fun ConfiguredDependency.statementOrNullIn( dependentProject: McProject ): DependencyDeclaration?</ID>
@@ -1066,7 +1023,6 @@
     <ID>UndocumentedPublicProperty:ProjectCollector.kt$ProjectCollector$val root: File</ID>
     <ID>UndocumentedPublicProperty:ProjectCollector.kt$ProjectCollector$val safeAnalysisResultAccess: SafeAnalysisResultAccess</ID>
     <ID>UndocumentedPublicProperty:ProjectContext.kt$ProjectContext.Element$val key: Key&lt;*></ID>
-    <ID>UndocumentedPublicProperty:ProjectPath.kt$ProjectPath$abstract val value: String</ID>
     <ID>UndocumentedPublicProperty:ProjectPath.kt$ProjectPath$val typeSafeValue: String by lazy { when (this) { is StringProjectPath -> value.typeSafeName() is TypeSafeProjectPath -> value } }</ID>
     <ID>UndocumentedPublicProperty:PsiElementWithSurroundingText.kt$PsiElementWithSurroundingText$val psiElement: PsiElement</ID>
     <ID>UndocumentedPublicProperty:PsiElementWithSurroundingText.kt$PsiElementWithSurroundingText$val statementText: String = psiElement.text</ID>
@@ -1096,7 +1052,7 @@
     <ID>UndocumentedPublicProperty:SourceSetBuilder.kt$SourceSetBuilder$val upstream: MutableList&lt;SourceSetName></ID>
     <ID>UndocumentedPublicProperty:SourceSetBuilder.kt$SourceSetBuilder$var annotationProcessorConfiguration: McConfiguration?</ID>
     <ID>UndocumentedPublicProperty:SourceSetBuilder.kt$SourceSetBuilder$var apiConfiguration: McConfiguration?</ID>
-    <ID>UndocumentedPublicProperty:SourceSetBuilder.kt$SourceSetBuilder$var classpath: MutableSet&lt;File> = mutableSetOf( File(CharRange::class.java.protectionDomain.codeSource.location.path) )</ID>
+    <ID>UndocumentedPublicProperty:SourceSetBuilder.kt$SourceSetBuilder$var classpath: MutableList&lt;File> = mutableListOf( File(CharRange::class.java.protectionDomain.codeSource.location.path) )</ID>
     <ID>UndocumentedPublicProperty:SourceSetBuilder.kt$SourceSetBuilder$var compileOnlyConfiguration: McConfiguration</ID>
     <ID>UndocumentedPublicProperty:SourceSetBuilder.kt$SourceSetBuilder$var implementationConfiguration: McConfiguration</ID>
     <ID>UndocumentedPublicProperty:SourceSetBuilder.kt$SourceSetBuilder$var jvmFiles: Set&lt;File></ID>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -153,6 +153,7 @@ kotlin-compile-testing = "com.github.tschuchortdev:kotlin-compile-testing:1.4.9"
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-coreCommon = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core-common", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-debug = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-debug", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-jdk8 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-jvm = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinx-coroutines" }

--- a/modulecheck-gradle/platforms/api/build.gradle.kts
+++ b/modulecheck-gradle/platforms/api/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
   api(project(path = ":modulecheck-model:sourceset:api"))
   api(project(path = ":modulecheck-parsing:gradle:model:api"))
   api(project(path = ":modulecheck-parsing:kotlin-compiler:api"))
+  api(project(path = ":modulecheck-utils:lazy"))
 
   compileOnly(gradleApi())
 

--- a/modulecheck-gradle/platforms/api/src/main/kotlin/modulecheck/gradle/platforms/KotlinEnvironmentFactory.kt
+++ b/modulecheck-gradle/platforms/api/src/main/kotlin/modulecheck/gradle/platforms/KotlinEnvironmentFactory.kt
@@ -18,6 +18,7 @@ package modulecheck.gradle.platforms
 import modulecheck.model.dependency.ProjectPath.StringProjectPath
 import modulecheck.model.sourceset.SourceSetName
 import modulecheck.parsing.kotlin.compiler.KotlinEnvironment
+import modulecheck.utils.lazy.LazyDeferred
 import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.LanguageVersion
 import java.io.File
@@ -36,7 +37,7 @@ fun interface KotlinEnvironmentFactory {
   fun create(
     projectPath: StringProjectPath,
     sourceSetName: SourceSetName,
-    classpathFiles: Lazy<Collection<File>>,
+    classpathFiles: LazyDeferred<List<File>>,
     sourceDirs: Collection<File>,
     kotlinLanguageVersion: LanguageVersion?,
     jvmTarget: JvmTarget

--- a/modulecheck-parsing/gradle/dsl/api/src/main/kotlin/modulecheck/parsing/gradle/dsl/AndroidGradleSettings.kt
+++ b/modulecheck-parsing/gradle/dsl/api/src/main/kotlin/modulecheck/parsing/gradle/dsl/AndroidGradleSettings.kt
@@ -42,7 +42,7 @@ data class AndroidGradleSettings(
 
 interface AndroidGradleSettingsProvider {
 
-  fun get(): AndroidGradleSettings
+  suspend fun get(): AndroidGradleSettings
 
   fun interface Factory {
     fun create(buildFile: File): AndroidGradleSettingsProvider
@@ -51,5 +51,5 @@ interface AndroidGradleSettingsProvider {
 
 interface AndroidGradleParser {
 
-  fun parse(buildFile: File): AndroidGradleSettings
+  suspend fun parse(buildFile: File): AndroidGradleSettings
 }

--- a/modulecheck-parsing/gradle/dsl/api/src/main/kotlin/modulecheck/parsing/gradle/dsl/PluginsBlock.kt
+++ b/modulecheck-parsing/gradle/dsl/api/src/main/kotlin/modulecheck/parsing/gradle/dsl/PluginsBlock.kt
@@ -26,7 +26,7 @@ interface PluginsBlock :
 
 interface PluginsBlockProvider {
 
-  fun get(): PluginsBlock?
+  suspend fun get(): PluginsBlock?
 
   fun interface Factory {
     fun create(buildFile: File): PluginsBlockProvider

--- a/modulecheck-parsing/gradle/dsl/internal/src/main/kotlin/modulecheck/parsing/gradle/dsl/internal/AbstractDependenciesBlock.kt
+++ b/modulecheck-parsing/gradle/dsl/internal/src/main/kotlin/modulecheck/parsing/gradle/dsl/internal/AbstractDependenciesBlock.kt
@@ -161,7 +161,7 @@ abstract class AbstractDependenciesBlock(
 
     _allDeclarations.add(declaration)
 
-    resetManager.resetAll()
+    resetManager.reset()
   }
 
   private fun List<String>.updateOldSuppresses(): List<String> {

--- a/modulecheck-parsing/gradle/dsl/internal/src/main/kotlin/modulecheck/parsing/gradle/dsl/internal/AbstractPluginsBlock.kt
+++ b/modulecheck-parsing/gradle/dsl/internal/src/main/kotlin/modulecheck/parsing/gradle/dsl/internal/AbstractPluginsBlock.kt
@@ -71,7 +71,7 @@ abstract class AbstractPluginsBlock(
       suppressed = suppressed.updateOldSuppresses() + blockSuppressed
     )
     _allDeclarations.add(declaration)
-    resetManager.resetAll()
+    resetManager.reset()
   }
 
   protected abstract fun findOriginalStringIndex(parsedString: String): Int

--- a/modulecheck-parsing/groovy-antlr/src/main/kotlin/modulecheck/parsing/groovy/antlr/GroovyAndroidGradleParser.kt
+++ b/modulecheck-parsing/groovy-antlr/src/main/kotlin/modulecheck/parsing/groovy/antlr/GroovyAndroidGradleParser.kt
@@ -35,7 +35,7 @@ import javax.inject.Inject
 
 class GroovyAndroidGradleParser @Inject constructor() : AndroidGradleParser {
 
-  override fun parse(buildFile: File): AndroidGradleSettings = parse(buildFile) {
+  override suspend fun parse(buildFile: File): AndroidGradleSettings = parse(buildFile) {
 
     val androidBlocks = mutableListOf<AndroidBlock>()
     val buildFeaturesBlocks = mutableListOf<BuildFeaturesBlock>()

--- a/modulecheck-parsing/kotlin-compiler/api/build.gradle.kts
+++ b/modulecheck-parsing/kotlin-compiler/api/build.gradle.kts
@@ -25,11 +25,11 @@ dependencies {
   api(libs.kotlin.compiler)
   api(libs.kotlin.reflect)
 
+  api(project(path = ":modulecheck-utils:lazy"))
+
   compileOnly(gradleApi())
 
   compileOnly(libs.agp)
-
-  implementation(project(path = ":modulecheck-utils:lazy"))
 
   testImplementation(libs.bundles.hermit)
   testImplementation(libs.bundles.jUnit)

--- a/modulecheck-parsing/kotlin-compiler/api/src/main/kotlin/modulecheck/parsing/kotlin/compiler/McPsiFileFactory.kt
+++ b/modulecheck-parsing/kotlin-compiler/api/src/main/kotlin/modulecheck/parsing/kotlin/compiler/McPsiFileFactory.kt
@@ -33,7 +33,7 @@ interface McPsiFileFactory {
    * @throws FileNotFoundException if the [file] does not exist in the Java file system
    * @since 0.13.0
    */
-  fun createKotlin(file: File): KtFile
+  suspend fun createKotlin(file: File): KtFile
 
   /**
    * @return a Psi `PsiJavaFile` for Java files. The file extension must be `.java`.
@@ -41,7 +41,7 @@ interface McPsiFileFactory {
    * @throws FileNotFoundException if the [file] does not exist in the Java file system
    * @since 0.13.0
    */
-  fun createJava(file: File): PsiJavaFile
+  suspend fun createJava(file: File): PsiJavaFile
 
   /**
    * Creates an instance of [McPsiFileFactory]

--- a/modulecheck-parsing/kotlin-compiler/api/src/main/kotlin/modulecheck/parsing/kotlin/compiler/internal/AbstractMcPsiFileFactory.kt
+++ b/modulecheck-parsing/kotlin-compiler/api/src/main/kotlin/modulecheck/parsing/kotlin/compiler/internal/AbstractMcPsiFileFactory.kt
@@ -16,6 +16,7 @@
 package modulecheck.parsing.kotlin.compiler.internal
 
 import modulecheck.parsing.kotlin.compiler.McPsiFileFactory
+import modulecheck.utils.lazy.LazyDeferred
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.com.intellij.psi.PsiFile
 import org.jetbrains.kotlin.com.intellij.psi.PsiJavaFile
@@ -37,11 +38,11 @@ abstract class AbstractMcPsiFileFactory : McPsiFileFactory {
    *
    * @since 0.13.0
    */
-  abstract val coreEnvironment: KotlinCoreEnvironment
+  abstract val coreEnvironment: LazyDeferred<KotlinCoreEnvironment>
 
-  protected abstract fun create(file: File): PsiFile
+  protected abstract suspend fun create(file: File): PsiFile
 
-  override fun createKotlin(file: File): KtFile {
+  override suspend fun createKotlin(file: File): KtFile {
     if (!file.exists()) throw FileNotFoundException("could not find file $file")
     if (!file.isKotlinFile()) throw IllegalArgumentException(
       "the file's extension must be either `.kt` or `.kts`, but it was `${file.extension}`."
@@ -50,7 +51,7 @@ abstract class AbstractMcPsiFileFactory : McPsiFileFactory {
     return create(file) as KtFile
   }
 
-  override fun createJava(file: File): PsiJavaFile {
+  override suspend fun createJava(file: File): PsiJavaFile {
 
     if (!file.isJavaFile()) {
       throw IllegalArgumentException(

--- a/modulecheck-parsing/kotlin-compiler/impl/build.gradle.kts
+++ b/modulecheck-parsing/kotlin-compiler/impl/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
   api(project(path = ":modulecheck-model:sourceset:api"))
   api(project(path = ":modulecheck-parsing:kotlin-compiler:api"))
   api(project(path = ":modulecheck-project:api"))
+  api(project(path = ":modulecheck-reporting:logging:api"))
   api(project(path = ":modulecheck-utils:lazy"))
 
   compileOnly(libs.agp)
@@ -49,4 +50,7 @@ dependencies {
   testImplementation(project(path = ":modulecheck-internal-testing"))
   testImplementation(project(path = ":modulecheck-parsing:kotlin-compiler:api"))
   testImplementation(project(path = ":modulecheck-parsing:kotlin-compiler:impl"))
+  testImplementation(project(path = ":modulecheck-parsing:psi"))
+  testImplementation(project(path = ":modulecheck-project:testing"))
+  testImplementation(project(path = ":modulecheck-utils:stdlib"))
 }

--- a/modulecheck-parsing/kotlin-compiler/impl/src/main/kotlin/modulecheck/parsing/kotlin/compiler/impl/McMessageCollector.kt
+++ b/modulecheck-parsing/kotlin-compiler/impl/src/main/kotlin/modulecheck/parsing/kotlin/compiler/impl/McMessageCollector.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2021-2022 Rick Busarow
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package modulecheck.parsing.kotlin.compiler.impl
+
+import modulecheck.parsing.kotlin.compiler.impl.McMessageCollector.LogLevel.ERRORS
+import modulecheck.parsing.kotlin.compiler.impl.McMessageCollector.LogLevel.VERBOSE
+import modulecheck.parsing.kotlin.compiler.impl.McMessageCollector.LogLevel.WARNINGS_AS_ERRORS
+import modulecheck.reporting.logging.McLogger
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
+
+internal class McMessageCollector(
+  private val messageRenderer: MessageRenderer,
+  private val logger: McLogger,
+  private val logLevel: LogLevel
+) : MessageCollector by MessageCollector.NONE {
+
+  private var totalMessages = 0
+  private var ignoredMessages = 0
+
+  override fun report(
+    severity: CompilerMessageSeverity,
+    message: String,
+    location: CompilerMessageSourceLocation?
+  ) {
+
+    totalMessages++
+
+    when (logLevel) {
+      ERRORS -> if (severity.isError) {
+        logger.printFailureLine(messageRenderer.render(severity, message, location))
+      } else {
+        ignoredMessages++
+      }
+
+      WARNINGS_AS_ERRORS -> if (severity.isWarning || severity.isError) {
+        logger.printFailureLine(messageRenderer.render(severity, message, location))
+      } else {
+        ignoredMessages++
+      }
+
+      VERBOSE -> if (severity.isWarning || severity.isError) {
+        logger.printFailureLine(messageRenderer.render(severity, message, location))
+      } else {
+        logger.printInfo(messageRenderer.render(severity, message, location))
+      }
+    }
+  }
+
+  override fun clear() {
+    ignoredMessages = 0
+    totalMessages = 0
+  }
+
+  override fun hasErrors(): Boolean = totalMessages > 0
+
+  fun printIssuesCountIfAny() {
+    if (ignoredMessages > 0) {
+      logger.printWarningLine("Analysis completed with $ignoredMessages ignored issues.")
+    }
+  }
+
+  enum class LogLevel {
+    ERRORS,
+    WARNINGS_AS_ERRORS,
+    VERBOSE
+  }
+}

--- a/modulecheck-parsing/kotlin-compiler/impl/src/main/kotlin/modulecheck/parsing/kotlin/compiler/impl/RealKotlinEnvironment.kt
+++ b/modulecheck-parsing/kotlin-compiler/impl/src/main/kotlin/modulecheck/parsing/kotlin/compiler/impl/RealKotlinEnvironment.kt
@@ -16,35 +16,32 @@
 package modulecheck.parsing.kotlin.compiler.impl
 
 import com.squareup.anvil.annotations.ContributesBinding
-import kotlinx.coroutines.flow.toList
 import modulecheck.dagger.TaskScope
 import modulecheck.gradle.platforms.KotlinEnvironmentFactory
 import modulecheck.model.dependency.ProjectPath.StringProjectPath
 import modulecheck.model.sourceset.SourceSetName
 import modulecheck.parsing.kotlin.compiler.KotlinEnvironment
 import modulecheck.parsing.kotlin.compiler.internal.isKotlinFile
-import modulecheck.utils.coroutines.mapAsync
+import modulecheck.reporting.logging.McLogger
+import modulecheck.utils.coroutines.flatMapSetMerge
 import modulecheck.utils.lazy.LazyDeferred
+import modulecheck.utils.lazy.ResetManager
 import modulecheck.utils.lazy.lazyDeferred
 import org.jetbrains.kotlin.analyzer.AnalysisResult
+import org.jetbrains.kotlin.builtins.jvm.JvmBuiltIns
+import org.jetbrains.kotlin.builtins.jvm.JvmBuiltIns.Kind.FROM_DEPENDENCIES
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.config.addKotlinSourceRoots
 import org.jetbrains.kotlin.cli.common.environment.setIdeaIoUseFallback
+import org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
-import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
-import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles.JVM_CONFIG_FILES
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.jvm.compiler.NoScopeRecordCliBindingTrace
+import org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM
 import org.jetbrains.kotlin.cli.jvm.config.addJavaSourceRoots
-import org.jetbrains.kotlin.com.intellij.mock.MockProject
-import org.jetbrains.kotlin.com.intellij.openapi.Disposable
-import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
-import org.jetbrains.kotlin.com.intellij.openapi.util.UserDataHolderBase
-import org.jetbrains.kotlin.com.intellij.pom.PomModel
-import org.jetbrains.kotlin.com.intellij.pom.PomModelAspect
-import org.jetbrains.kotlin.com.intellij.pom.PomTransaction
-import org.jetbrains.kotlin.com.intellij.pom.impl.PomTransactionBase
-import org.jetbrains.kotlin.com.intellij.pom.tree.TreeAspect
+import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoots
+import org.jetbrains.kotlin.com.intellij.psi.PsiJavaFile
 import org.jetbrains.kotlin.config.ApiVersion
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
@@ -52,37 +49,45 @@ import org.jetbrains.kotlin.config.JVMConfigurationKeys
 import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
+import org.jetbrains.kotlin.config.languageVersionSettings
+import org.jetbrains.kotlin.context.ContextForNewModule
+import org.jetbrains.kotlin.context.ProjectContext
 import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
 import org.jetbrains.kotlin.incremental.isJavaFile
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.lazy.declarations.FileBasedDeclarationProviderFactory
-import sun.reflect.ReflectionFactory
 import java.io.File
 import javax.inject.Inject
 
 /**
  * @property projectPath path of the associated Gradle project
  * @property sourceSetName name of the associated
- *   [SourceSet][modulecheck.parsing.gradle.model.McSourceSet]
+ *     [SourceSet][modulecheck.model.dependency.McSourceSet]
  * @property classpathFiles `.jar` files from external dependencies
  * @property sourceDirs all jvm source code directories for this source set, like
- *   `[...]/myProject/src/main/java`.
+ *     `[...]/myProject/src/main/java`.
  * @property kotlinLanguageVersion the version of Kotlin being used
  * @property jvmTarget the version of Java being compiled to
  * @property safeAnalysisResultAccess provides thread-safe, "leased" access to the ModuleDescriptors
- *   of dependencies, since only one downstream project can safely
- *   consume (and update the cache of) a descriptor at any given time
+ *     of dependencies, since only one downstream project can safely consume (and update the cache
+ *     of) a descriptor at any given time
+ * @property logger logs Kotlin compiler messages during analysis
+ * @property resetManager used to reset caching
  * @since 0.13.0
  */
 @Suppress("LongParameterList")
 class RealKotlinEnvironment(
   val projectPath: StringProjectPath,
   val sourceSetName: SourceSetName,
-  val classpathFiles: Lazy<Collection<File>>,
+  val classpathFiles: LazyDeferred<List<File>>,
   private val sourceDirs: Collection<File>,
   val kotlinLanguageVersion: LanguageVersion?,
-  private val jvmTarget: JvmTarget,
-  val safeAnalysisResultAccess: SafeAnalysisResultAccess
+  val jvmTarget: JvmTarget,
+  val safeAnalysisResultAccess: SafeAnalysisResultAccess,
+  val logger: McLogger,
+  private val resetManager: ResetManager
 ) : KotlinEnvironment {
 
   private val sourceFiles by lazy {
@@ -92,7 +97,7 @@ class RealKotlinEnvironment(
       .toSet()
   }
 
-  override val compilerConfiguration by lazy {
+  override val compilerConfiguration = lazyDeferred {
     createCompilerConfiguration(
       sourceFiles = sourceFiles.toList(),
       kotlinLanguageVersion = kotlinLanguageVersion,
@@ -100,20 +105,47 @@ class RealKotlinEnvironment(
     )
   }
 
-  override val coreEnvironment by lazy { createKotlinCoreEnvironment(compilerConfiguration) }
-
-  override val psiFileFactory by lazy { RealMcPsiFileFactory(this) }
-
-  override val javaFiles by lazy {
-    sourceFiles.filter { it.isJavaFile() }
-      .associateWith { file -> psiFileFactory.createJava(file) }
+  override val coreEnvironment = lazyDeferred {
+    createKotlinCoreEnvironment(compilerConfiguration.await())
   }
-  override val ktFiles by lazy {
-    sourceFiles.filter { it.isKotlinFile() }
-      .associateWith { file -> psiFileFactory.createKotlin(file) }
+
+  override val lightPsiFactory = lazyDeferred {
+    RealMcPsiFileFactory(this)
+  }
+
+  override val heavyPsiFactory = lazyDeferred {
+    analysisResultDeferred.await()
+    RealMcPsiFileFactory(this)
+  }
+
+  override suspend fun bestAvailablePsiFactory(): RealMcPsiFileFactory {
+    return when {
+      heavyPsiFactory.isCompleted -> heavyPsiFactory.getCompleted()
+      analysisResultDeferred.isCompleted -> heavyPsiFactory.await()
+      else -> lightPsiFactory.await()
+    }
+  }
+
+  private val kotlinSourceFiles by lazy { sourceFiles.filter { it.isKotlinFile() } }
+
+  override suspend fun javaPsiFile(file: File): PsiJavaFile {
+    // Type resolution for Java Psi files assumes that analysis has already been run.
+    // Otherwise, we get:
+    // `UninitializedPropertyAccessException: lateinit property module has not been initialized`
+    analysisResultDeferred.await()
+    return heavyPsiFactory.await().createJava(file)
+  }
+
+  override suspend fun ktFile(file: File): KtFile {
+    return bestAvailablePsiFactory().createKotlin(file)
   }
 
   override val analysisResultDeferred: LazyDeferred<AnalysisResult> = lazyDeferred {
+
+    val psiFactory = lightPsiFactory.await()
+
+    val ktFiles = kotlinSourceFiles
+      .map { file -> psiFactory.createKotlin(file) }
 
     safeAnalysisResultAccess.withLeases(
       requester = this,
@@ -121,15 +153,18 @@ class RealKotlinEnvironment(
       sourceSetName = sourceSetName
     ) { dependencyEnvironments ->
 
+      @Suppress("UNCHECKED_CAST")
       val descriptors = dependencyEnvironments
-        .mapAsync { dependency ->
-          dependency.moduleDescriptorDeferred.await()
+        .flatMapSetMerge { dependency ->
+          val directDependency = dependency.moduleDescriptorDeferred.await()
+          setOf(directDependency)
+            .plus(directDependency.allDependencyModules as List<ModuleDescriptorImpl>)
         }
         .toList()
 
-      maybeCreateAnalysisResult(
-        coreEnvironment = coreEnvironment,
-        ktFiles = ktFiles.values.toList(),
+      createAnalysisResult(
+        coreEnvironment = coreEnvironment.await(),
+        ktFiles = ktFiles,
         dependencyModuleDescriptors = descriptors
       )
     }
@@ -140,7 +175,117 @@ class RealKotlinEnvironment(
   }
 
   override val moduleDescriptorDeferred: LazyDeferred<ModuleDescriptorImpl> = lazyDeferred {
-    analysisResultDeferred.await().moduleDescriptor as ModuleDescriptorImpl
+    val golden = analysisResultDeferred.await().moduleDescriptor as ModuleDescriptorImpl
+    golden.copy()
+  }
+
+  private suspend fun ModuleDescriptorImpl.copy(): ModuleDescriptorImpl {
+    val project = coreEnvironment.await().project
+
+    val projectContext = ProjectContext(project, "testing project context")
+    val builtIns = JvmBuiltIns(projectContext.storageManager, FROM_DEPENDENCIES)
+
+    val mutableModuleContext = ContextForNewModule(
+      projectContext,
+      Name.special(
+        "<${projectPath.value}:${sourceSetName.value} ${kotlin.random.Random.nextInt()}>"
+      ),
+      builtIns,
+      JvmPlatforms.jvmPlatformByTargetVersion(jvmTarget)
+    )
+
+    mutableModuleContext.module.setDependencies(
+      allDependencyModules.filterIsInstance<ModuleDescriptorImpl>()
+    )
+
+    mutableModuleContext.module.initialize(this.packageFragmentProvider)
+
+    return mutableModuleContext.module
+  }
+
+  private val messageCollector by lazy {
+    McMessageCollector(
+      messageRenderer = MessageRenderer.GRADLE_STYLE,
+      logger = logger,
+      logLevel = McMessageCollector.LogLevel.WARNINGS_AS_ERRORS
+    )
+  }
+
+  private fun createAnalysisResult(
+    coreEnvironment: KotlinCoreEnvironment,
+    ktFiles: List<KtFile>,
+    dependencyModuleDescriptors: List<ModuleDescriptorImpl>
+  ): AnalysisResult {
+
+    val analyzer = AnalyzerWithCompilerReport(
+      messageCollector,
+      coreEnvironment.configuration.languageVersionSettings
+    )
+
+    analyzer.analyzeAndReport(ktFiles) {
+      TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration(
+        project = coreEnvironment.project,
+        files = ktFiles,
+        trace = NoScopeRecordCliBindingTrace(),
+        configuration = coreEnvironment.configuration,
+        packagePartProvider = coreEnvironment::createPackagePartProvider,
+        declarationProviderFactory = ::FileBasedDeclarationProviderFactory,
+        explicitModuleDependencyList = dependencyModuleDescriptors
+      )
+    }
+
+    messageCollector.printIssuesCountIfAny()
+
+    return analyzer.analysisResult
+  }
+
+  private suspend fun createCompilerConfiguration(
+    sourceFiles: List<File>,
+    kotlinLanguageVersion: LanguageVersion?,
+    jvmTarget: JvmTarget
+  ): CompilerConfiguration {
+    val javaFiles = mutableListOf<File>()
+    val kotlinFiles = mutableListOf<String>()
+
+    sourceFiles.forEach { file ->
+      when {
+        file.isKotlinFile() -> kotlinFiles.add(file.absolutePath)
+        file.isJavaFile() -> javaFiles.add(file)
+      }
+    }
+
+    return CompilerConfiguration().apply {
+      put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, messageCollector)
+      put(JVMConfigurationKeys.JVM_TARGET, jvmTarget)
+      put(CommonConfigurationKeys.MODULE_NAME, "${projectPath.value}:${sourceSetName.value}")
+
+      if (kotlinLanguageVersion != null) {
+        val languageVersionSettings = LanguageVersionSettingsImpl(
+          languageVersion = kotlinLanguageVersion,
+          apiVersion = ApiVersion.createByLanguageVersion(kotlinLanguageVersion)
+        )
+        put(CommonConfigurationKeys.LANGUAGE_VERSION_SETTINGS, languageVersionSettings)
+      }
+
+      put(JVMConfigurationKeys.JVM_TARGET, jvmTarget)
+
+      addJavaSourceRoots(javaFiles)
+      addKotlinSourceRoots(kotlinFiles)
+      addJvmClasspathRoots(classpathFiles.await())
+    }
+  }
+
+  private fun createKotlinCoreEnvironment(
+    configuration: CompilerConfiguration
+  ): KotlinCoreEnvironment {
+    // https://github.com/JetBrains/kotlin/commit/2568804eaa2c8f6b10b735777218c81af62919c1
+    setIdeaIoUseFallback()
+
+    return KotlinCoreEnvironment.createForProduction(
+      parentDisposable = resetManager,
+      configuration = configuration,
+      configFiles = JVM_CONFIG_FILES
+    )
   }
 
   /**
@@ -150,12 +295,13 @@ class RealKotlinEnvironment(
    */
   @ContributesBinding(TaskScope::class)
   class Factory @Inject constructor(
-    private val safeAnalysisResultAccess: SafeAnalysisResultAccess
+    private val safeAnalysisResultAccess: SafeAnalysisResultAccess,
+    private val logger: McLogger
   ) : KotlinEnvironmentFactory {
     override fun create(
       projectPath: StringProjectPath,
       sourceSetName: SourceSetName,
-      classpathFiles: Lazy<Collection<File>>,
+      classpathFiles: LazyDeferred<List<File>>,
       sourceDirs: Collection<File>,
       kotlinLanguageVersion: LanguageVersion?,
       jvmTarget: JvmTarget
@@ -166,125 +312,9 @@ class RealKotlinEnvironment(
       sourceDirs = sourceDirs,
       kotlinLanguageVersion = kotlinLanguageVersion,
       jvmTarget = jvmTarget,
-      safeAnalysisResultAccess = safeAnalysisResultAccess
+      safeAnalysisResultAccess = safeAnalysisResultAccess,
+      logger = logger,
+      resetManager = ResetManager()
     )
-  }
-}
-
-private fun maybeCreateAnalysisResult(
-  coreEnvironment: KotlinCoreEnvironment,
-  ktFiles: List<KtFile>,
-  dependencyModuleDescriptors: List<ModuleDescriptorImpl>
-): AnalysisResult {
-  return VersionNeutralTopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration(
-    project = coreEnvironment.project,
-    files = ktFiles,
-    trace = NoScopeRecordCliBindingTrace(),
-    configuration = coreEnvironment.configuration,
-    packagePartProvider = coreEnvironment::createPackagePartProvider,
-    declarationProviderFactory = ::FileBasedDeclarationProviderFactory,
-    explicitModuleDependencyList = dependencyModuleDescriptors
-  )
-}
-
-private fun createCompilerConfiguration(
-  sourceFiles: List<File>,
-  kotlinLanguageVersion: LanguageVersion?,
-  jvmTarget: JvmTarget
-): CompilerConfiguration {
-  val javaFiles = mutableListOf<File>()
-  val kotlinFiles = mutableListOf<String>()
-
-  sourceFiles.forEach { file ->
-    when {
-      file.isKotlinFile() -> kotlinFiles.add(file.absolutePath)
-      file.isJavaFile() -> javaFiles.add(file)
-    }
-  }
-
-  return CompilerConfiguration().apply {
-    put(
-      CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY,
-      PrintingMessageCollector(
-        System.err,
-        MessageRenderer.PLAIN_FULL_PATHS,
-        false
-      )
-    )
-
-    if (kotlinLanguageVersion != null) {
-      val languageVersionSettings = LanguageVersionSettingsImpl(
-        languageVersion = kotlinLanguageVersion,
-        apiVersion = ApiVersion.createByLanguageVersion(kotlinLanguageVersion)
-      )
-      put(CommonConfigurationKeys.LANGUAGE_VERSION_SETTINGS, languageVersionSettings)
-    }
-
-    put(JVMConfigurationKeys.JVM_TARGET, jvmTarget)
-
-    addJavaSourceRoots(javaFiles)
-    addKotlinSourceRoots(kotlinFiles)
-    // addJvmClasspathRoots(classpathFiles)
-  }
-}
-
-/*
-Borrowed from Detekt
-https://github.com/detekt/detekt/blob/master/detekt-parser/src/main/kotlin/io/github/detekt/parser/KotlinEnvironmentUtils.kt
- */
-private fun createKotlinCoreEnvironment(
-  configuration: CompilerConfiguration,
-  disposable: Disposable = Disposer.newDisposable()
-): KotlinCoreEnvironment {
-  // https://github.com/JetBrains/kotlin/commit/2568804eaa2c8f6b10b735777218c81af62919c1
-  setIdeaIoUseFallback()
-  configuration.put(CommonConfigurationKeys.MODULE_NAME, "moduleCheck")
-
-  val environment = KotlinCoreEnvironment.createForProduction(
-    disposable,
-    configuration,
-    EnvironmentConfigFiles.JVM_CONFIG_FILES
-  )
-
-  val projectCandidate = environment.project
-
-  val project = requireNotNull(projectCandidate as? MockProject) {
-    "MockProject type expected, actual - ${projectCandidate.javaClass.simpleName}"
-  }
-
-  project.registerService(PomModel::class.java, ModuleCheckPomModel())
-
-  return environment
-}
-
-/**
- * https://github.com/pinterest/ktlint/blob/69cc0f7f826e18d7ec20e7a0f05df12d53a3c1e1/ktlint-core/src/main/kotlin/com/pinterest/ktlint/core/internal/KotlinPsiFileFactory.kt#L70
- *
- * @since 0.13.0
- */
-private class ModuleCheckPomModel : UserDataHolderBase(), PomModel {
-
-  override fun runTransaction(transaction: PomTransaction) {
-    val transactionCandidate = transaction as? PomTransactionBase
-
-    val pomTransaction = requireNotNull(transactionCandidate) {
-      "expected ${PomTransactionBase::class.simpleName} " +
-        "but actual was ${transaction.javaClass.simpleName}"
-    }
-
-    pomTransaction.run()
-  }
-
-  override fun <T : PomModelAspect?> getModelAspect(aspect: Class<T>): T? {
-    if (aspect == TreeAspect::class.java) {
-      // using approach described in https://git.io/vKQTo due to the magical bytecode of TreeAspect
-      // (check constructor signature and compare it to the source)
-      // (org.jetbrains.kotlin:kotlin-compiler-embeddable:1.0.3)
-      val constructor = ReflectionFactory.getReflectionFactory()
-        .newConstructorForSerialization(aspect, Any::class.java.getDeclaredConstructor())
-      @Suppress("UNCHECKED_CAST")
-      return constructor.newInstance() as T
-    }
-    return null
   }
 }

--- a/modulecheck-parsing/kotlin-compiler/impl/src/main/kotlin/modulecheck/parsing/kotlin/compiler/impl/VersionNeutralTopDownAnalyzerFacadeForJVM.kt
+++ b/modulecheck-parsing/kotlin-compiler/impl/src/main/kotlin/modulecheck/parsing/kotlin/compiler/impl/VersionNeutralTopDownAnalyzerFacadeForJVM.kt
@@ -52,9 +52,8 @@ object VersionNeutralTopDownAnalyzerFacadeForJVM {
    * so that we can use the [BindingContext][org.jetbrains.kotlin.resolve.BindingContext] for type
    * resolution.
    *
-   * Note that this process is eager, and can be very time-consuming for large
-   * projects or projects with lots of internal dependencies. It's only a bit
-   * faster than doing a normal compilation. This function is called when the lazy
+   * Note that this process is eager, and can be very time-consuming
+   * for large projects. This function is called when the lazy
    * [KotlinEnvironment.bindingContext][modulecheck.parsing.kotlin.compiler.KotlinEnvironment.bindingContextDeferred]
    * is accessed.
    *

--- a/modulecheck-parsing/kotlin-compiler/impl/src/test/kotlin/modulecheck/parsing/kotlin/compiler/impl/RealKotlinEnvironmentTest.kt
+++ b/modulecheck-parsing/kotlin-compiler/impl/src/test/kotlin/modulecheck/parsing/kotlin/compiler/impl/RealKotlinEnvironmentTest.kt
@@ -1,0 +1,289 @@
+/*
+ * Copyright (C) 2021-2022 Rick Busarow
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package modulecheck.parsing.kotlin.compiler.impl
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.types.shouldBeTypeOf
+import modulecheck.model.dependency.ConfigurationName
+import modulecheck.model.sourceset.SourceSetName
+import modulecheck.parsing.kotlin.compiler.internal.isKtFile
+import modulecheck.parsing.psi.internal.getChildrenOfTypeRecursive
+import modulecheck.project.test.ProjectTest
+import org.jetbrains.kotlin.incremental.isJavaFile
+import org.jetbrains.kotlin.js.descriptorUtils.getJetTypeFqName
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.types.UnresolvedType
+import org.jetbrains.kotlin.types.isNullable
+import org.junit.jupiter.api.Test
+
+@Suppress("UnusedPrivateMember")
+class RealKotlinEnvironmentTest : ProjectTest() {
+
+  @Test
+  fun `resolution should work for sources from a dependency module`() = test {
+
+    val lib1 = kotlinProject(":lib1") {
+
+      addKotlinSource(
+        """
+        package com.modulecheck.lib1
+
+        class Lib1Class(val name: String)
+        """,
+        fileName = "Lib1Class.kt"
+      )
+    }
+    val subject = kotlinProject(":subject") {
+      addDependency(ConfigurationName.api, lib1)
+
+      addKotlinSource(
+        """
+        package com.modulecheck.subject
+
+        import com.modulecheck.lib1.Lib1Class
+
+        class SubjectClass {
+          val lib1 = Lib1Class("foo")
+        }
+        """
+      )
+    }
+
+    val sourceSet = subject.sourceSets[SourceSetName.MAIN]!!
+    val kotlinEnvironment = sourceSet.kotlinEnvironmentDeferred.await() as RealKotlinEnvironment
+    val bindingContext = kotlinEnvironment.bindingContextDeferred.await()
+
+    val ktFile = kotlinEnvironment.ktFile(sourceSet.jvmFiles.single())
+
+    val property = ktFile.getChildrenOfTypeRecursive<KtProperty>().single()
+    val propertyDescriptor = bindingContext[BindingContext.VARIABLE, property]!!
+
+    val propertyType = propertyDescriptor.returnType!!
+
+    assertSoftly {
+      propertyType.getJetTypeFqName(true) shouldBe "com.modulecheck.lib1.Lib1Class"
+      propertyType.isNullable() shouldBe false
+    }
+  }
+
+  @Test
+  fun `resolution should work for sources from an upstream source set in the same module`() = test {
+
+    val subject = kotlinProject(":subject") {
+
+      addKotlinSource(
+        """
+        package com.modulecheck.subject
+
+        class DepClass
+        """
+      )
+
+      addKotlinSource(
+        """
+        package com.modulecheck.subject
+
+        class SubjectClass {
+          val dep = DepClass()
+        }
+        """,
+        sourceSetName = SourceSetName.TEST
+      )
+    }
+
+    val sourceSet = subject.sourceSets[SourceSetName.TEST]!!
+    val kotlinEnvironment = sourceSet.kotlinEnvironmentDeferred.await()
+    val bindingContext = kotlinEnvironment.bindingContextDeferred.await()
+
+    val ktFile = kotlinEnvironment.ktFile(sourceSet.jvmFiles.single())
+
+    val property = ktFile.getChildrenOfTypeRecursive<KtProperty>().first()
+
+    val propertyDescriptor = bindingContext[BindingContext.VARIABLE, property]!!
+
+    val propertyType = propertyDescriptor.returnType!!
+
+    assertSoftly {
+      propertyType.getJetTypeFqName(true) shouldBe "com.modulecheck.subject.DepClass"
+      propertyType.isNullable() shouldBe false
+    }
+  }
+
+  @Test
+  fun `resolution should work for java source from an upstream source set in the same module`() =
+    test {
+
+      val subject = kotlinProject(":subject") {
+
+        addJavaSource(
+          """
+        package com.modulecheck.subject;
+
+        class DepClass {}
+        """
+        )
+
+        addKotlinSource(
+          """
+        package com.modulecheck.subject
+
+        class SubjectClass {
+          val dep = DepClass()
+        }
+        """,
+          sourceSetName = SourceSetName.TEST
+        )
+      }
+
+      val sourceSet = subject.sourceSets[SourceSetName.TEST]!!
+      val kotlinEnvironment = sourceSet.kotlinEnvironmentDeferred.await()
+      val bindingContext = kotlinEnvironment.bindingContextDeferred.await()
+
+      val ktFile = kotlinEnvironment.ktFile(sourceSet.jvmFiles.single())
+
+      val property = ktFile.getChildrenOfTypeRecursive<KtProperty>().single()
+      val propertyDescriptor = bindingContext[BindingContext.VARIABLE, property]!!
+
+      val propertyType = propertyDescriptor.returnType!!
+
+      assertSoftly {
+        propertyType.getJetTypeFqName(true) shouldBe "com.modulecheck.subject.DepClass"
+        propertyType.isNullable() shouldBe false
+      }
+    }
+
+  @Test
+  fun `resolution should work for java dependency source in the same source set`() = test {
+
+    val subject = kotlinProject(":subject") {
+
+      addJavaSource(
+        """
+        package com.modulecheck.subject;
+
+        class DepClass {}
+        """
+      )
+
+      addKotlinSource(
+        """
+        package com.modulecheck.subject
+
+        class SubjectClass {
+          val dep = DepClass()
+        }
+        """
+      )
+    }
+
+    val sourceSet = subject.sourceSets[SourceSetName.MAIN]!!
+    val kotlinEnvironment = sourceSet.kotlinEnvironmentDeferred.await()
+    val bindingContext = kotlinEnvironment.bindingContextDeferred.await()
+
+    val ktFile = kotlinEnvironment.ktFile(sourceSet.jvmFiles.single { it.isKtFile() })
+
+    val property = ktFile.getChildrenOfTypeRecursive<KtProperty>().single()
+    val propertyDescriptor = bindingContext[BindingContext.VARIABLE, property]!!
+
+    val propertyType = propertyDescriptor.returnType!!
+
+    assertSoftly {
+      propertyType.getJetTypeFqName(true) shouldBe "com.modulecheck.subject.DepClass"
+      propertyType.isNullable() shouldBe false
+    }
+  }
+
+  @Test
+  fun `resolution should work for java source in the same source set`() = test {
+
+    val subject = kotlinProject(":subject") {
+
+      addKotlinSource(
+        """
+        package com.modulecheck.subject
+
+        @Deprecated("no")
+        class DepClass
+        """
+      )
+
+      addJavaSource(
+        """
+        package com.modulecheck.subject;
+
+        class SubjectClass {
+          DepClass dep = new DepClass();
+        }
+        """
+      )
+    }
+
+    val sourceSet = subject.sourceSets[SourceSetName.MAIN]!!
+    val kotlinEnvironment = sourceSet.kotlinEnvironmentDeferred.await()
+
+    val javaFile = kotlinEnvironment.javaPsiFile(sourceSet.jvmFiles.single { it.isJavaFile() })
+
+    val property = javaFile.classes.single().fields.single()
+
+    val propertyType = property.type
+
+    // type resolution for Java Psi files assumes that analysis has already been run
+    kotlinEnvironment.analysisResultDeferred.await()
+
+    propertyType.canonicalText shouldBe "com.modulecheck.subject.DepClass"
+  }
+
+  @Test
+  fun `resolution does not work for references which arent real`() = test {
+
+    val subject = kotlinProject(":subject") {
+
+      addKotlinSource(
+        """
+        package com.modulecheck.subject
+
+        class SubjectClass {
+
+          val property : com.fake.Fake<String>? = null
+        }
+        """
+      )
+    }
+
+    val sourceSet = subject.sourceSets[SourceSetName.MAIN]!!
+    val kotlinEnvironment = sourceSet.kotlinEnvironmentDeferred.await()
+    val bindingContext = kotlinEnvironment.bindingContextDeferred.await()
+
+    val ktFile = kotlinEnvironment.ktFile(sourceSet.jvmFiles.single())
+
+    val property = ktFile.getChildrenOfTypeRecursive<KtProperty>().single()
+    val propertyDescriptor = bindingContext[BindingContext.VARIABLE, property]!!
+
+    val propertyType = propertyDescriptor.returnType!!
+
+    assertSoftly {
+      propertyType.shouldBeTypeOf<UnresolvedType>()
+      propertyType.getJetTypeFqName(false) shouldBe ""
+      propertyType.presentableName shouldBe "com.fake.Fake<String>"
+      propertyType.isNullable() shouldBe true
+
+      propertyType.arguments.single()
+        .type
+        .getJetTypeFqName(false) shouldBe String::class.qualifiedName
+    }
+  }
+}

--- a/modulecheck-parsing/psi/src/main/kotlin/modulecheck/parsing/psi/KotlinAndroidGradleParser.kt
+++ b/modulecheck-parsing/psi/src/main/kotlin/modulecheck/parsing/psi/KotlinAndroidGradleParser.kt
@@ -41,7 +41,7 @@ class KotlinAndroidGradleParser @Inject constructor(
   private val psiFileFactory: NoContextPsiFileFactory
 ) : AndroidGradleParser {
 
-  override fun parse(buildFile: File): AndroidGradleSettings {
+  override suspend fun parse(buildFile: File): AndroidGradleSettings {
 
     val file = psiFileFactory.createKotlin(buildFile)
 

--- a/modulecheck-parsing/psi/src/test/kotlin/modulecheck/parsing/psi/KotlinPluginsBlockParserTest.kt
+++ b/modulecheck-parsing/psi/src/test/kotlin/modulecheck/parsing/psi/KotlinPluginsBlockParserTest.kt
@@ -26,7 +26,7 @@ internal class KotlinPluginsBlockParserTest : BaseTest() {
   val logger by resets { PrintLogger() }
 
   @Test
-  fun `external declaration`() {
+  fun `external declaration`() = test {
     val block = parse(
       """
        plugins {
@@ -60,7 +60,7 @@ internal class KotlinPluginsBlockParserTest : BaseTest() {
   }
 
   @Test
-  fun `suppressed kotlin function`() {
+  fun `suppressed kotlin function`() = test {
     val block = parse(
       """
        plugins {
@@ -81,7 +81,7 @@ internal class KotlinPluginsBlockParserTest : BaseTest() {
   }
 
   @Test
-  fun `suppressed back-ticked ID`() {
+  fun `suppressed back-ticked ID`() = test {
     val block = parse(
       """
        plugins {
@@ -102,7 +102,7 @@ internal class KotlinPluginsBlockParserTest : BaseTest() {
   }
 
   @Test
-  fun `suppression which doesn't match finding name regex should be ignored`() {
+  fun `suppression which doesn't match finding name regex should be ignored`() = test {
     val block = parse(
       """
        @Suppress("DSL_SCOPE_VIOLATION")
@@ -116,7 +116,7 @@ internal class KotlinPluginsBlockParserTest : BaseTest() {
   }
 
   @Test
-  fun `suppressed id function`() {
+  fun `suppressed id function`() = test {
     val block = parse(
       """
        plugins {
@@ -137,7 +137,7 @@ internal class KotlinPluginsBlockParserTest : BaseTest() {
   }
 
   @Test
-  fun `suppressed with old finding name`() {
+  fun `suppressed with old finding name`() = test {
     val block = parse(
       """
        plugins {
@@ -157,7 +157,7 @@ internal class KotlinPluginsBlockParserTest : BaseTest() {
     )
   }
 
-  fun parse(
+  suspend fun parse(
     string: String
   ): KotlinPluginsBlock {
     val file = NoContextPsiFileFactory()

--- a/modulecheck-parsing/source/testing/src/main/kotlin/modulecheck/parsing/test/McNameTest.kt
+++ b/modulecheck-parsing/source/testing/src/main/kotlin/modulecheck/parsing/test/McNameTest.kt
@@ -15,6 +15,8 @@
 
 package modulecheck.parsing.test
 
+import io.kotest.assertions.asClue
+import io.kotest.assertions.assertSoftly
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import modulecheck.parsing.source.AndroidDataBindingDeclaredName
@@ -120,9 +122,17 @@ interface McNameTest : FancyShould {
 
     val other = JvmFileBuilder().also { it.config() }
 
-    references shouldBe other.referenceNames
-    apiReferences shouldBe other.apiReferenceNames
-    declarations shouldBe other.declarations
+    assertSoftly {
+      "references".asClue {
+        references shouldBe other.referenceNames
+      }
+      "api references".asClue {
+        apiReferences shouldBe other.apiReferenceNames
+      }
+      "declarations".asClue {
+        declarations shouldBe other.declarations
+      }
+    }
   }
 
   infix fun Collection<QualifiedDeclaredName>.shouldBe(other: Collection<QualifiedDeclaredName>) {

--- a/modulecheck-parsing/wiring/src/main/kotlin/modulecheck/parsing/wiring/RealAndroidGradleSettingsProvider.kt
+++ b/modulecheck-parsing/wiring/src/main/kotlin/modulecheck/parsing/wiring/RealAndroidGradleSettingsProvider.kt
@@ -32,7 +32,7 @@ class RealAndroidGradleSettingsProvider(
   private val buildFile: File
 ) : AndroidGradleSettingsProvider {
 
-  override fun get(): AndroidGradleSettings {
+  override suspend fun get(): AndroidGradleSettings {
     return when {
       buildFile.isKotlinFile(listOf("kts")) -> kotlinParser.parse(buildFile)
       buildFile.extension == "gradle" -> groovyParser.parse(buildFile)

--- a/modulecheck-parsing/wiring/src/main/kotlin/modulecheck/parsing/wiring/RealJvmFileProvider.kt
+++ b/modulecheck-parsing/wiring/src/main/kotlin/modulecheck/parsing/wiring/RealJvmFileProvider.kt
@@ -100,7 +100,7 @@ class RealJvmFileProvider(
       when {
         file.isKtFile() -> RealKotlinFile(
           file = file,
-          psi = kotlinEnvironment.ktFiles.getValue(file),
+          psi = kotlinEnvironment.ktFile(file),
           psiResolver = PsiElementResolver(
             project = project,
             sourceSetName = sourceSetName
@@ -110,7 +110,7 @@ class RealJvmFileProvider(
 
         else -> RealJavaFile(
           file = file,
-          psi = kotlinEnvironment.javaFiles.getValue(file),
+          psi = kotlinEnvironment.javaPsiFile(file),
           jvmTarget = sourceSet.jvmTarget,
           nameParser = nameParser
         )

--- a/modulecheck-parsing/wiring/src/main/kotlin/modulecheck/parsing/wiring/RealPluginsBlockProvider.kt
+++ b/modulecheck-parsing/wiring/src/main/kotlin/modulecheck/parsing/wiring/RealPluginsBlockProvider.kt
@@ -34,7 +34,7 @@ class RealPluginsBlockProvider(
   private val psiFileFactory: NoContextPsiFileFactory
 ) : PluginsBlockProvider {
 
-  override fun get(): PluginsBlock? {
+  override suspend fun get(): PluginsBlock? {
     return when {
       buildFile.isKotlinFile(listOf("kts")) ->
         kotlinParser

--- a/modulecheck-project-generation/api/src/main/kotlin/modulecheck/project/generation/ProjectCollector.kt
+++ b/modulecheck-project-generation/api/src/main/kotlin/modulecheck/project/generation/ProjectCollector.kt
@@ -37,6 +37,7 @@ import modulecheck.project.McProject
 import modulecheck.project.ProjectCache
 import modulecheck.project.ProjectProvider
 import modulecheck.utils.lazy.lazySet
+import org.jetbrains.annotations.Contract
 import org.jetbrains.kotlin.config.JvmTarget
 import java.io.File
 
@@ -137,6 +138,7 @@ interface ProjectCollector {
     )
   }
 
+  @Contract(pure = true, value = "_->new")
   suspend fun McProject.editSimple(
     config: McProjectBuilder<PlatformPluginBuilder<PlatformPlugin>>.() -> Unit = {}
   ): McProject {

--- a/modulecheck-project/testing/build.gradle.kts
+++ b/modulecheck-project/testing/build.gradle.kts
@@ -25,6 +25,7 @@ mcbuild {
 dependencies {
 
   api(libs.bundles.hermit)
+  api(libs.kotlinx.coroutines.debug)
 
   api(project(path = ":modulecheck-config:api"))
   api(project(path = ":modulecheck-internal-testing"))

--- a/modulecheck-utils/lazy/build.gradle.kts
+++ b/modulecheck-utils/lazy/build.gradle.kts
@@ -23,6 +23,7 @@ mcbuild {
 
 dependencies {
 
+  api(libs.kotlin.compiler)
   api(libs.kotlinx.coroutines.core)
   api(libs.kotlinx.coroutines.jvm)
 

--- a/modulecheck-utils/lazy/src/main/kotlin/modulecheck/utils/lazy/LazyDeferred.kt
+++ b/modulecheck-utils/lazy/src/main/kotlin/modulecheck/utils/lazy/LazyDeferred.kt
@@ -37,6 +37,16 @@ import kotlinx.coroutines.sync.withLock
 interface LazyDeferred<out T> {
   val isCompleted: Boolean
   suspend fun await(): T
+
+  /**
+   * Immediately returns the deferred value **if already completed**.
+   *
+   * This should only be called after manually checking the value of [isCompleted].
+   *
+   * @throws [IllegalStateException] if this deferred value has not [completed][isCompleted] yet.
+   * @since 0.13.0
+   */
+  fun getCompleted(): T
 }
 
 /**
@@ -94,6 +104,12 @@ internal class LazyDeferredImpl<T>(
         }
       }
     }
+    @Suppress("UNCHECKED_CAST")
+    return _value as T
+  }
+
+  override fun getCompleted(): T {
+    check(_completed) { "LazyDeferred has not been completed yet." }
     @Suppress("UNCHECKED_CAST")
     return _value as T
   }

--- a/modulecheck-utils/lazy/src/main/kotlin/modulecheck/utils/lazy/LazyResets.kt
+++ b/modulecheck-utils/lazy/src/main/kotlin/modulecheck/utils/lazy/LazyResets.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2021-2022 Rick Busarow
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package modulecheck.utils.lazy
+
+import kotlinx.coroutines.DisposableHandle
+import org.jetbrains.kotlin.com.intellij.openapi.Disposable
+
+interface LazyResets<out T : Any> : Lazy<T>, Resets
+
+interface Resets {
+  fun reset()
+}
+
+inline fun <reified T : Any> ResetManager.lazyResets(
+  noinline valueFactory: () -> T
+): LazyResets<T> = LazyResets(this, valueFactory)
+
+fun <T : Any> LazyResets(
+  resetManager: ResetManager,
+  valueFactory: () -> T
+): LazyResets<T> = LazyResetsImpl(resetManager, valueFactory)
+
+internal class LazyResetsImpl<out T : Any>(
+  private val resetManager: ResetManager,
+  private val valueFactory: () -> T
+) : LazyResets<T> {
+
+  private var lazyHolder: Lazy<T> = createLazy()
+
+  override val value: T
+    get() = lazyHolder.value
+
+  override fun isInitialized(): Boolean = lazyHolder.isInitialized()
+
+  private fun createLazy() = lazy {
+    resetManager.register(this)
+    valueFactory()
+  }
+
+  override fun reset() {
+    lazyHolder = createLazy()
+  }
+}
+
+interface ResetManager : Resets, Disposable {
+  fun register(delegate: Resets)
+
+  override fun dispose()
+
+  override fun reset()
+  fun child(childDelegates: MutableCollection<Resets> = mutableListOf()): ResetManager
+
+  companion object {
+    operator fun invoke(): ResetManager = RealResetManager()
+  }
+}
+
+object EmptyResetManager : ResetManager {
+  override fun register(delegate: Resets) = Unit
+  override fun dispose() = Unit
+  override fun reset() = Unit
+  override fun child(childDelegates: MutableCollection<Resets>) = this
+}
+
+class RealResetManager(
+  private val delegates: MutableCollection<Resets> = mutableListOf()
+) : DisposableHandle, ResetManager {
+
+  override fun register(delegate: Resets) {
+    synchronized(delegates) {
+      delegates.add(delegate)
+    }
+  }
+
+  override fun dispose() = reset()
+  override fun reset() {
+    synchronized(delegates) {
+      delegates.forEach { it.reset() }
+      delegates.clear()
+    }
+  }
+
+  override fun child(childDelegates: MutableCollection<Resets>): RealResetManager {
+    return RealResetManager(childDelegates)
+      .also { child -> register(child) }
+  }
+}


### PR DESCRIPTION
This touches a bunch of files, mostly because I had to make some properties `LazyDeferred` instead of `Lazy`, and the resultant `suspend` modifier trickles down.

In essence, these changes force Psi analysis before we can access any java Psi files, but not the Kotlin files (they don't need it).

Also, this adds a `ModuleDescriptorImpl.copy()` function, using some internal JetBrains apis which probably aren't stable.  It's my hope that I'll be able to use this to provide a true deep copy of descriptors for any module wishing to use them for dependency descriptors.  This means the loss of the descriptor's internal caching, but it also means that analysis can be performed for multiple downstream modules simultaneously - which should be a significant performance improvement in most cases.  I'll be working on that change in the near future.