### PR TITLE
revert the `project.isRootOfComposite()` check for matrix-yaml

### DIFF
--- a/build-logic/core/src/main/kotlin/modulecheck/builds/file.kt
+++ b/build-logic/core/src/main/kotlin/modulecheck/builds/file.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2021-2022 Rick Busarow
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package builds
+
+import java.io.File
+
+/**
+ * Walks upward in the file tree, looking for a directory which will resolve [relativePath].
+ *
+ * For example, given a receiver File path of './a/b/c/' and a `relativePath` of 'foo/bar.txt', this
+ * function will attempt to resolve the following paths in order:
+ * ```text
+ * ./a/b/c/foo/bar.txt
+ * ./a/b/foo/bar.txt
+ * ./a/foo/bar.txt
+ * ./foo/bar.txt
+ * ```
+ *
+ * @returns the first path to contain an [existent][File.exists] File for [relativePath], or `null`
+ *     if it could not be resolved
+ * @see resolveInParent for a version which throws if nothing is resolved
+ */
+fun File.resolveInParentOrNull(relativePath: String): File? {
+  return resolve(relativePath).existsOrNull()
+    ?: parentFile?.resolveInParentOrNull(relativePath)
+}
+
+/**
+ * Non-nullable version of [resolveInParentOrNull]
+ *
+ * @throws IllegalArgumentException if a file cannot be resolved
+ * @see resolveInParentOrNull for a nullable, non-throwing variant
+ */
+fun File.resolveInParent(relativePath: String): File {
+  return requireNotNull(resolveInParentOrNull(relativePath)) {
+    "Could not resolve a file with relative path in any parent paths.\n" +
+      "\t       relative path: $relativePath\n" +
+      "\tstarting parent path: $absolutePath"
+  }
+}
+
+fun File.existsOrNull(): File? = takeIf { it.exists() }
+
+fun File.isDirectoryWithFiles(): Boolean = takeIf { it.isDirectory }
+  ?.listFiles()
+  ?.any { it.isDirectory } == true

--- a/build-logic/mcbuild/src/main/kotlin/mcbuild.matrix-yaml.gradle.kts
+++ b/build-logic/mcbuild/src/main/kotlin/mcbuild.matrix-yaml.gradle.kts
@@ -13,16 +13,17 @@
  * limitations under the License.
  */
 
-import modulecheck.builds.isRootOfComposite
 import modulecheck.builds.matrix.VersionsMatrixYamlCheckTask
 import modulecheck.builds.matrix.VersionsMatrixYamlGenerateTask
 
-require(project.isRootOfComposite()) {
-  "only add the ci/yaml matrix tasks to the root project"
+val ciFile = rootProject.file(".github/workflows/ci.yml")
+
+require(ciFile.exists()) {
+  "Could not resolve '$ciFile'.  Only add the ci/yaml matrix tasks to the root project."
 }
 
 val versionsMatrixYamlCheck by tasks.registering(VersionsMatrixYamlCheckTask::class) {
-  yamlFile.set(rootProject.file(".github/workflows/ci.yml"))
+  yamlFile.set(ciFile)
 }
 
 // Automatically run `versionsMatrixYamlCheck` when running `check`
@@ -33,5 +34,5 @@ tasks
   }
 
 tasks.register("versionsMatrixGenerateYaml", VersionsMatrixYamlGenerateTask::class) {
-  yamlFile.set(rootProject.file(".github/workflows/ci.yml"))
+  yamlFile.set(ciFile)
 }


### PR DESCRIPTION
The intent was to make sure that the plugin was only applied to ModuleCheck's root.  Unfortunately, the super-strict `isRootOfComposite()` check also makes it so that the project can never be included in a downstream consumer project.  With this check, if MC is added as an included build, every Gradle invocation fails.