### PR TITLE
use BuildProperties for `RuleUrlValidationTest`'s websiteDir

### DIFF
--- a/modulecheck-core/build.gradle.kts
+++ b/modulecheck-core/build.gradle.kts
@@ -20,6 +20,17 @@ plugins {
 mcbuild {
   artifactId = "modulecheck-core"
   anvil()
+
+  buildProperties(
+    "test",
+    """
+    package modulecheck.core
+
+    internal class BuildProperties {
+      val websiteDir = "${rootDir.resolve("website").invariantSeparatorsPath}"
+    }
+    """
+  )
 }
 
 dependencies {

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/RuleUrlValidationTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/RuleUrlValidationTest.kt
@@ -27,18 +27,14 @@ import modulecheck.utils.child
 import modulecheck.utils.remove
 import modulecheck.utils.requireNotNull
 import org.junit.jupiter.api.Test
-import kotlin.io.path.Path
-import kotlin.io.path.absolute
+import java.io.File
 
 class RuleUrlValidationTest : RunnerTest() {
 
   @Test
   fun `each rule documentation url must correspond to a docs file and sidebar entry`() {
 
-    val websiteDir = Path(".").absolute()
-      .parent
-      .parent
-      .child("website")
+    val websiteDir = File(BuildProperties().websiteDir)
 
     """
       The path must point to the project website: $websiteDir


### PR DESCRIPTION
This test has been flaking lately on Windows.