### PR TITLE
replace homemade BuildProperties generation with `com.github.gmazzo.buildconfig`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,10 +87,16 @@ jobs:
           arguments: artifactsCheck
           cache-read-only: false
 
-      - name: detekt
+      - name: detektAll
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: detekt detektMain detektTest
+          arguments: detektAll
+          cache-read-only: false
+
+      - name: merge detekt SARIF reports
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: detektReportMerge
           cache-read-only: false
 
       - name: Upload SARIF to Github using the upload-sarif action

--- a/.idea/ktlint.xml
+++ b/.idea/ktlint.xml
@@ -1,24 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KtlintProjectConfiguration">
-    <enableKtlint>false</enableKtlint>
-    <androidMode>true</androidMode>
     <useExperimental>true</useExperimental>
     <treatAsErrors>false</treatAsErrors>
-    <lintAfterReformat>false</lintAfterReformat>
-    <disabledRules>
-      <list>
-        <option value="max-line-length" />
-        <option value="filename" />
-        <option value="no-empty-first-line-in-method-block" />
-        <option value="experimental:function-signature" />
-        <option value="dot-spacing" />
-      </list>
-    </disabledRules>
-    <externalJarPaths>
-      <list>
-        <option value="build-logic/ktlint-rules/build/libs/ktlint-rules.jar" />
-      </list>
-    </externalJarPaths>
+    <formatOnSave>true</formatOnSave>
   </component>
 </project>

--- a/build-logic/conventions/build.gradle.kts
+++ b/build-logic/conventions/build.gradle.kts
@@ -94,6 +94,7 @@ dependencies {
   compileOnly(libs.kotlin.gradle.plugin)
 
   implementation(libs.benManes.versions)
+  implementation(libs.buildconfig)
   implementation(libs.detekt.gradle)
   implementation(libs.dokka.gradle)
   implementation(libs.dropbox.dependencyGuard)

--- a/build-logic/conventions/src/main/kotlin/modulecheck/builds/BuildPropertiesExtension.kt
+++ b/build-logic/conventions/src/main/kotlin/modulecheck/builds/BuildPropertiesExtension.kt
@@ -15,130 +15,143 @@
 
 package modulecheck.builds
 
+import com.github.gmazzo.gradle.plugins.BuildConfigExtension
+import com.github.gmazzo.gradle.plugins.BuildConfigPlugin
 import org.gradle.api.Project
-import org.gradle.api.tasks.TaskProvider
-import org.intellij.lang.annotations.Language
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
-import org.jetbrains.kotlin.util.prefixIfNot
-import org.jetbrains.kotlin.util.suffixIfNot
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import java.io.File
+import kotlin.LazyThreadSafetyMode.NONE
+import kotlin.reflect.KClass
 
 interface BuildPropertiesExtension {
 
-  fun Project.buildProperties(
-    sourceSetName: String,
-    @Language("kotlin")
-    content: String
+  fun Project.buildConfig(
+    sourceSetName: String = "main",
+    internalVisibility: Boolean = true,
+    config: BuildConfigBuilderScope.() -> Unit
   ) {
-    setUpGeneration(
+
+    plugins.apply(BuildConfigPlugin::class.java)
+
+    BuildConfigBuilderScope(
+      project = this,
       sourceSetName = sourceSetName,
-      content = content.trimIndent()
-    )
+      internalVisibility = internalVisibility
+    ).config()
   }
 }
 
-private fun Project.setUpGeneration(
-  sourceSetName: String,
-  @Language("kotlin")
-  content: String
+@Suppress("MemberVisibilityCanBePrivate")
+class BuildConfigBuilderScope(
+  private val project: Project,
+  private val sourceSetName: String,
+  private val internalVisibility: Boolean
 ) {
 
-  val generatedDir = generatedDir(sourceSetName)
+  // Shadow the common project properties eagerly,
+  // so that the project instance isn't accidentally referenced during task runtime.
+  val rootDir: File = project.rootDir
+  val projectDir: File = project.projectDir
 
-  extensions.configure(KotlinJvmProjectExtension::class.java) { extension ->
-    extension.sourceSets.named(sourceSetName) {
-      it.kotlin.srcDir(generatedDir)
+  val normalSourceRoot: DirectoryProperty = project.objects.directoryProperty()
+    .convention(
+      project.layout.dir(
+        project.provider {
+          projectDir.resolve("src/$sourceSetName/kotlin")
+        }
+      )
+    )
+
+  val packageName: Property<String> = project.objects.property(String::class.java)
+    .convention(
+      normalSourceRoot.map { dir ->
+
+        val root = dir.asFile
+        val minDir = root
+          .walkTopDown()
+          .filter { it.isDirectoryWithFiles { file -> file.extension == "kt" } }
+          .minByOrNull { it.path.length }
+          ?.relativeTo(root)
+
+        checkNotNull(minDir) {
+          "Could not find a kotlin file in the source directory of: file://$normalSourceRoot"
+        }
+
+        minDir.path.split(File.separator).joinToString(".")
+      }
+    )
+
+  private val sourceSet by lazy(NONE) {
+    project.extensions
+      .getByType(BuildConfigExtension::class.java)
+      .sourceSets
+      .maybeRegister(sourceSetName) { buildConfigSourceSet ->
+
+        buildConfigSourceSet.className.convention("BuildProperties")
+        buildConfigSourceSet.packageName.convention(packageName)
+
+        buildConfigSourceSet.useKotlinOutput { generator ->
+          if (internalVisibility) {
+            generator.internalVisibility = true
+          }
+        }
+
+        project.registerSimpleGenerationTaskAsDependency(
+          sourceSetName,
+          buildConfigSourceSet.generateTask
+        )
+      }
+  }
+
+  fun <T : Any> field(name: String, value: T) {
+
+    sourceSet.configure { buildConfigSourceSet ->
+      val valueString = getValueString(value)
+
+      buildConfigSourceSet.buildConfigField(value::class.java.simpleName, name, valueString)
     }
   }
 
-  val (packageName, className) = packageNameToClassName(content)
-  val buildPropertiesFile = generatedFile(
-    sourceSetName = sourceSetName,
-    packageName = packageName,
-    className = className
-  )
-
-  val genTask = registerTask(
-    sourceSetName = sourceSetName,
-    generatedDir = generatedDir,
-    buildPropertiesFile = buildPropertiesFile,
-    content = content
-  )
-
-  registerSimpleGenerationTaskAsDependency(
-    sourceSetName = sourceSetName,
-    taskProvider = genTask
-  )
-}
-
-private fun Project.registerTask(
-  sourceSetName: String,
-  generatedDir: File,
-  buildPropertiesFile: File,
-  content: String
-): TaskProvider<ModuleCheckBuildCodeGeneratorTask> {
-  val catalogs = rootProject.file(
-    "build-logic/core/src/main/kotlin/modulecheck/builds/catalogs.kt"
-  )
-
-  val sourceSetTaskName = when (sourceSetName) {
-    "main" -> ""
-    else -> sourceSetName.capitalize()
+  fun field(name: String, valueProvider: () -> String) {
+    field(name, String::class, project.provider { valueProvider() })
   }
 
-  return tasks.register(
-    "generate${sourceSetTaskName}BuildProperties",
-    ModuleCheckBuildCodeGeneratorTask::class.java
-  ) {
-    it.inputs.file(catalogs)
+  fun field(name: String, valueProvider: Provider<String>) {
+    field(name, String::class, valueProvider)
+  }
 
-    it.outputs.file(buildPropertiesFile)
+  fun <T : Any> field(name: String, type: KClass<out Any>, valueProvider: () -> T) {
+    field(name, type, project.provider { valueProvider() })
+  }
 
-    it.doLast {
-      generatedDir.deleteRecursively()
-      buildPropertiesFile.parentFile.mkdirs()
-      buildPropertiesFile.writeText(
-        content.prefixIfNot("@file:Suppress(\"AbsentOrWrongFileLicense\")\n\n")
-          .suffixIfNot("\n")
+  fun <T : Any> field(name: String, type: KClass<out Any>, valueProvider: Provider<T>) {
+
+    sourceSet.configure { buildConfigSourceSet ->
+      buildConfigSourceSet.buildConfigField(
+        type = type.qualifiedName!!,
+        name = name,
+        value = valueProvider.map { getValueString(it) }
       )
     }
   }
-}
 
-private fun Project.generatedDir(sourceSetName: String): File {
-  return buildDir.resolve(
-    "generated/sources/buildProperties/kotlin/$sourceSetName"
-  )
-}
+  @PublishedApi
+  internal fun <T : Any> getValueString(value: T) = when (value) {
+    is String -> {
+      check(!value.startsWith("\\\"") && !value.endsWith("\\\"")) {
+        "Don't add escaped quotes manually.  The Kable extension will do that automagically.\n" +
+          "The `value` argument was (underscores added): _${value}_"
+      }
 
-private fun packageNameToClassName(content: String): Pair<String, String> {
-
-  val packageNameRegex = "package (\\S*)".toRegex()
-
-  val lines = content.lines()
-    .filter { it.isNotBlank() }
-
-  val packageName = lines.first { it.trim().matches(packageNameRegex) }
-    .replace(packageNameRegex) { match ->
-      match.destructured.component1().trim()
+      "\"$value\""
     }
 
-  val classNameRegex = "internal class (\\S*).*".toRegex()
-
-  val typeName = lines.first { it.trim().matches(classNameRegex) }
-    .replace(classNameRegex) { match ->
-      match.destructured.component1().trim()
-    }
-
-  return packageName to typeName
-}
-
-private fun Project.generatedFile(
-  sourceSetName: String,
-  packageName: String,
-  className: String
-): File {
-  return generatedDir(sourceSetName)
-    .resolve(packageName.replace(".", File.separator))
-    .resolve("$className.kt")
+    // For file paths, turn '/Users/<username>/Development/kable/extras/some-folder'
+    //                 into '../../extras/some-folder'
+    is File -> "\"${value.relativeTo(projectDir)}\""
+    is Number -> "$value"
+    else -> "\"$value\""
+  }
 }

--- a/build-logic/conventions/src/main/kotlin/modulecheck/builds/DependencyGuardConventionPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/modulecheck/builds/DependencyGuardConventionPlugin.kt
@@ -43,15 +43,15 @@ abstract class DependencyGuardConventionPlugin : Plugin<Project> {
       Delete::class.java
     ) { it.delete("dependencies") }
 
-    target.tasks.named(LifecycleBasePlugin.CHECK_TASK_NAME) {
+    target.tasks.named(LifecycleBasePlugin.CHECK_TASK_NAME).configure {
       it.dependsOn("dependencyGuard")
     }
 
-    target.tasks.named("dependencyGuardBaseline") {
+    target.tasks.named("dependencyGuardBaseline").configure {
       it.dependsOn(dependencyGuardDeleteBaselines)
       it.finalizedBy(target.rootProject.tasks.matchingName("dependencyGuardAggregate"))
     }
-    target.tasks.named("dependencyGuard") {
+    target.tasks.named("dependencyGuard").configure {
       it.dependsOn(target.rootProject.tasks.matchingName("dependencyGuardExplode"))
       it.finalizedBy(dependencyGuardDeleteBaselines)
     }

--- a/build-logic/conventions/src/main/kotlin/modulecheck/builds/KtLintConventionPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/modulecheck/builds/KtLintConventionPlugin.kt
@@ -42,19 +42,19 @@ abstract class KtLintConventionPlugin : Plugin<Project> {
       target.addRootProjectDelegateTasks()
     }
 
-    target.tasks.named("lintKotlin") {
+    target.tasks.named("lintKotlin").configure {
       it.mustRunAfter(target.tasks.named("formatKotlin"))
     }
 
     if (target == target.rootProject) {
       target.addGradleScriptTasks(target.tasks, taskNameQualifier = "")
 
-      target.tasks.named("lintKotlin") { rootLint ->
+      target.tasks.named("lintKotlin").configure { rootLint ->
         target.subprojects { sub ->
           rootLint.dependsOn(sub.tasks.matchingName("lintKotlin"))
         }
       }
-      target.tasks.named("formatKotlin") { rootLint ->
+      target.tasks.named("formatKotlin").configure { rootLint ->
         target.subprojects { sub ->
           rootLint.dependsOn(sub.tasks.matchingName("formatKotlin"))
         }
@@ -63,7 +63,7 @@ abstract class KtLintConventionPlugin : Plugin<Project> {
 
     target.afterEvaluate {
 
-      target.tasks.withType(ConfigurableKtLintTask::class.java) { task ->
+      target.tasks.withType(ConfigurableKtLintTask::class.java).configureEach { task ->
         excludeGenerated(task, target)
       }
     }

--- a/build-logic/core/src/main/kotlin/modulecheck/builds/tasks.kt
+++ b/build-logic/core/src/main/kotlin/modulecheck/builds/tasks.kt
@@ -116,7 +116,6 @@ fun Task.undecoratedTypeName(): String {
   return javaClass.canonicalName.removeSuffix("_Decorated")
 }
 
-
 fun <T : Any> NamedDomainObjectContainer<T>.maybeRegister(name: String): NamedDomainObjectProvider<T> {
   return if (names.contains(name)) {
     named(name)

--- a/build-logic/core/src/main/kotlin/modulecheck/builds/tasks.kt
+++ b/build-logic/core/src/main/kotlin/modulecheck/builds/tasks.kt
@@ -16,6 +16,8 @@
 package modulecheck.builds
 
 import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.Task
 import org.gradle.api.tasks.TaskCollection
 import org.gradle.api.tasks.TaskContainer
@@ -112,4 +114,22 @@ fun <T : Task> TaskContainer.registerOnce(
  */
 fun Task.undecoratedTypeName(): String {
   return javaClass.canonicalName.removeSuffix("_Decorated")
+}
+
+
+fun <T : Any> NamedDomainObjectContainer<T>.maybeRegister(name: String): NamedDomainObjectProvider<T> {
+  return if (names.contains(name)) {
+    named(name)
+  } else {
+    register(name)
+  }
+}
+
+fun <T : Any> NamedDomainObjectContainer<T>.maybeRegister(
+  name: String,
+  configuration: Action<in T>
+): NamedDomainObjectProvider<T> = if (names.contains(name)) {
+  named(name, configuration)
+} else {
+  register(name, configuration)
 }

--- a/build-logic/versions-matrix/build.gradle.kts
+++ b/build-logic/versions-matrix/build.gradle.kts
@@ -34,7 +34,7 @@ gradlePlugin {
   plugins {
     create("mcbuild.matrix-yaml") {
       id = "mcbuild.matrix-yaml"
-      implementationClass = "VersionsMatrixYamlPlugin"
+      implementationClass = "modulecheck.builds.matrix.VersionsMatrixYamlPlugin"
     }
   }
 }

--- a/modulecheck-core/build.gradle.kts
+++ b/modulecheck-core/build.gradle.kts
@@ -21,16 +21,9 @@ mcbuild {
   artifactId = "modulecheck-core"
   anvil()
 
-  buildProperties(
-    "test",
-    """
-    package modulecheck.core
-
-    internal class BuildProperties {
-      val websiteDir = "${rootDir.resolve("website").invariantSeparatorsPath}"
-    }
-    """
-  )
+  buildConfig("test") {
+    field("websiteDir") { rootDir.resolve("website").invariantSeparatorsPath }
+  }
 }
 
 dependencies {

--- a/modulecheck-core/src/test/kotlin/modulecheck/core/RuleUrlValidationTest.kt
+++ b/modulecheck-core/src/test/kotlin/modulecheck/core/RuleUrlValidationTest.kt
@@ -33,7 +33,7 @@ class RuleUrlValidationTest : RunnerTest() {
   @Test
   fun `each rule documentation url must correspond to a docs file and sidebar entry`() {
 
-    val websiteDir = File(BuildProperties().websiteDir)
+    val websiteDir = File(BuildProperties.websiteDir)
 
     """
       The path must point to the project website: $websiteDir

--- a/modulecheck-gradle/plugin/build.gradle.kts
+++ b/modulecheck-gradle/plugin/build.gradle.kts
@@ -24,18 +24,18 @@ mcbuild {
   artifactId = "modulecheck-gradle-plugin"
   dagger()
 
-  buildProperties(
-    "main",
-    """
-    package modulecheck.gradle.internal
-
-    internal class BuildProperties {
-      val version = "${modulecheck.builds.VERSION_NAME}"
-      val sourceWebsite = "${modulecheck.builds.SOURCE_WEBSITE}"
-      val docsWebsite = "${modulecheck.builds.DOCS_WEBSITE}"
-    }
-    """
-  )
+  buildConfig {
+    packageName.set("modulecheck.gradle.internal")
+    field("version") { modulecheck.builds.VERSION_NAME }
+    field("sourceWebsite") { modulecheck.builds.SOURCE_WEBSITE }
+    field("docsWebsite") { modulecheck.builds.DOCS_WEBSITE }
+  }
+  buildConfig("integrationTest") {
+    packageName.set("modulecheck.gradle.internal")
+    field("version") { modulecheck.builds.VERSION_NAME }
+    field("sourceWebsite") { modulecheck.builds.SOURCE_WEBSITE }
+    field("docsWebsite") { modulecheck.builds.DOCS_WEBSITE }
+  }
 }
 
 val main by sourceSets.getting

--- a/modulecheck-gradle/plugin/src/integrationTest/kotlin/modulecheck/gradle/RuntimeClasspathValidationTest.kt
+++ b/modulecheck-gradle/plugin/src/integrationTest/kotlin/modulecheck/gradle/RuntimeClasspathValidationTest.kt
@@ -52,7 +52,7 @@ class RuntimeClasspathValidationTest : BaseGradleTest() {
                 useVersion("$agp")
               }
               if (requested.id.id == "com.rickbusarow.module-check") {
-                useVersion("${BuildProperties().version}")
+                useVersion("${BuildProperties.version}")
               }
               if (requested.id.id.startsWith("org.jetbrains.kotlin")) {
                 useVersion("$kotlin")

--- a/modulecheck-gradle/plugin/src/main/kotlin/modulecheck/gradle/internal/RealDocsWebsiteUrlProvider.kt
+++ b/modulecheck-gradle/plugin/src/main/kotlin/modulecheck/gradle/internal/RealDocsWebsiteUrlProvider.kt
@@ -24,15 +24,15 @@ import javax.inject.Inject
 
 @ContributesBinding(TaskScope::class)
 class RealDocsWebsiteUrlProvider @Inject constructor() : DocsWebsiteUrlProvider {
-  override fun get(): String = BuildProperties().docsWebsite
+  override fun get(): String = BuildProperties.docsWebsite
 }
 
 @ContributesBinding(TaskScope::class)
 class RealSourceWebsiteUrlProvider @Inject constructor() : SourceWebsiteUrlProvider {
-  override fun get(): String = BuildProperties().sourceWebsite
+  override fun get(): String = BuildProperties.sourceWebsite
 }
 
 @ContributesBinding(TaskScope::class)
 class RealModuleCheckVersionProvider @Inject constructor() : ModuleCheckVersionProvider {
-  override fun get(): String = BuildProperties().version
+  override fun get(): String = BuildProperties.version
 }

--- a/modulecheck-gradle/plugin/src/test/kotlin/modulecheck/gradle/BaseGradleTest.kt
+++ b/modulecheck-gradle/plugin/src/test/kotlin/modulecheck/gradle/BaseGradleTest.kt
@@ -99,7 +99,7 @@ abstract class BaseGradleTest :
             useVersion("$agpVersion")
           }
           if (requested.id.id == "com.rickbusarow.module-check") {
-            useVersion("${BuildProperties().version}")
+            useVersion("${BuildProperties.version}")
           }
           if (requested.id.id.startsWith("org.jetbrains.kotlin")) {
             useVersion("$kotlinVersion")

--- a/modulecheck-internal-testing/src/main/kotlin/modulecheck/testing/propTest.kt
+++ b/modulecheck-internal-testing/src/main/kotlin/modulecheck/testing/propTest.kt
@@ -15,6 +15,7 @@
 
 package modulecheck.testing
 
+import io.kotest.common.ExperimentalKotest
 import io.kotest.property.Gen
 import io.kotest.property.PropTestConfig
 import io.kotest.property.PropertyContext
@@ -30,6 +31,7 @@ fun <A> forAllBlocking(
   property: suspend PropertyContext.(A) -> Unit
 ) {
   runBlocking<Unit> {
+    @OptIn(ExperimentalKotest::class)
     io.kotest.property.forAll(PropTestConfig(), genA) {
       property.invoke(this, it)
       true


### PR DESCRIPTION
This is mostly done just because the new plugin's config is lazy.  The new convention plugin is copy/pasted from one of my internal projects.