### PR TITLE
support toggling `mavenLocal()` repositories from gradle properties

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -16,16 +16,31 @@
 rootProject.name = "build-logic"
 
 pluginManagement {
+
+  val allowMavenLocal = providers
+    .gradleProperty("moduleCheck.allow-maven-local")
+    .orNull.toBoolean()
+
   repositories {
+    if (allowMavenLocal) {
+      mavenLocal()
+    }
     mavenCentral()
     google()
     maven("https://plugins.gradle.org/m2/")
   }
 }
 
+val allowMavenLocal = providers
+  .gradleProperty("moduleCheck.allow-maven-local")
+  .orNull.toBoolean()
+
 dependencyResolutionManagement {
   @Suppress("UnstableApiUsage")
   repositories {
+    if (allowMavenLocal) {
+      mavenLocal()
+    }
     mavenCentral()
     google()
     maven("https://plugins.gradle.org/m2/")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -15,7 +15,7 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,16 @@
  */
 
 pluginManagement {
+
+  val allowMavenLocal = providers
+    .gradleProperty("moduleCheck.allow-maven-local")
+    .orNull.toBoolean()
+
   repositories {
+    if (allowMavenLocal) {
+      println("allowing mavenLocal")
+      mavenLocal()
+    }
     gradlePluginPortal()
     mavenCentral()
     google()
@@ -29,9 +38,16 @@ pluginManagement {
   includeBuild("build-logic")
 }
 
+val allowMavenLocal = providers
+  .gradleProperty("moduleCheck.allow-maven-local")
+  .orNull.toBoolean()
+
 dependencyResolutionManagement {
   @Suppress("UnstableApiUsage")
   repositories {
+    if (allowMavenLocal) {
+      mavenLocal()
+    }
     mavenCentral()
     google()
     maven("https://plugins.gradle.org/m2/")
@@ -39,7 +55,7 @@ dependencyResolutionManagement {
 }
 
 plugins {
-  id("com.gradle.enterprise").version("3.13.3")
+  id("com.gradle.enterprise") version "3.13.3"
 }
 
 val isCI = System.getenv("CI")?.toBoolean() == true
@@ -159,16 +175,21 @@ fun printCiEnvironment() {
   val maxMemory = Runtime.getRuntime().maxMemory().gigabytes()
   println(
     """
-    ╔══════════════════════════════════════════════════════════════════════════════╗
-    ║                                CI environment                                ║
-    ║                                                                              ║
-    ║                     OS - $os║
-    ║   available processors - $processors║
-    ║                                                                              ║
-    ║           total memory - $totalMemory║
-    ║            free memory - $freeMemory║
-    ║             max memory - $maxMemory║
-    ╚══════════════════════════════════════════════════════════════════════════════╝
+    ╔══════════════════════════════════════════════════╗
+    ║                  CI environment                  ║
+    ║                                                  ║
+    ║                     OS - $os                     ║
+    ║   available processors - $processors             ║
+    ║                                                  ║
+    ║       allocated memory - $totalMemory            ║
+    ║            free memory - $freeMemory             ║
+    ║             max memory - $maxMemory              ║
+    ╚══════════════════════════════════════════════════╝
     """.trimIndent()
+      .lineSequence()
+      .joinToString("\n") { line ->
+        val sub = line.substringBeforeLast('║', "")
+        if (sub.length > 51) sub.substring(0..50) + '║' else line
+      }
   )
 }


### PR DESCRIPTION
This uses the `moduleCheck.allow-maven-local` property to possibly include `mavenLocal()` as a repository everywhere.

THe property can be set in `~/.gradle/gradle.properties`.